### PR TITLE
ci: update GitHub Actions to v7

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,10 +14,10 @@ jobs:
 
     steps:
       - name: Check out repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
 
       - name: Set up Node.js
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@v7
         with:
           node-version: 20
           cache: npm

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -24,7 +24,7 @@ jobs:
 
     steps:
       - name: Check out repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
 
       - name: Initialize CodeQL
         uses: github/codeql-action/init@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,10 +20,10 @@ jobs:
 
     steps:
       - name: Check out tagged source
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
 
       - name: Set up Node.js
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@v7
         with:
           node-version: 20
           cache: npm


### PR DESCRIPTION
## Summary

- update actions/checkout from v6 to v7 in CI, CodeQL, and release workflows
- update actions/setup-node from v6 to v7 wherever Node.js is initialized
- keep every public workflow on the same major action versions

## Why

The earlier Dependabot PRs were created before the release workflow existed, so merging them directly would leave workflow versions inconsistent. This replaces those partial updates with one current-main change.

## Validation

- git diff --check
- verified every checkout/setup-node reference under .github/workflows uses v7
- required Verify and CodeQL checks must pass before merge