### PR TITLE
chore: update runtime dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,20 +8,20 @@
       "name": "paper-collage-video-pipeline",
       "version": "0.4.0",
       "license": "MIT",
-      "engines": {
-        "node": ">=20"
-      },
       "dependencies": {
-        "@remotion/cli": "4.0.489",
+        "@remotion/cli": "4.0.490",
         "react": "19.2.7",
         "react-dom": "19.2.7",
-        "remotion": "4.0.489"
+        "remotion": "4.0.490"
       },
       "devDependencies": {
         "@types/react": "19.2.17",
         "@types/react-dom": "19.2.3",
         "sharp": "0.35.3",
         "typescript": "5.9.3"
+      },
+      "engines": {
+        "node": ">=20"
       }
     },
     "node_modules/@babel/helper-string-parser": {
@@ -1192,21 +1192,21 @@
       }
     },
     "node_modules/@remotion/bundler": {
-      "version": "4.0.489",
-      "resolved": "https://registry.npmjs.org/@remotion/bundler/-/bundler-4.0.489.tgz",
-      "integrity": "sha512-f2uLJfo3Ar3YiW32aiEdf7JTJgnMQEjdMLSdIaf/8GSktJ5yfqKxjL9mIRfIaYiRVjp99jCzcb2I4yqDwIbfNg==",
+      "version": "4.0.490",
+      "resolved": "https://registry.npmjs.org/@remotion/bundler/-/bundler-4.0.490.tgz",
+      "integrity": "sha512-AZe7ncD+b0OUap5ZT8T0boONa7+I7Ap4+kAh5BZOa5sVaBjz4YI7eqILXtGqi+kNuBsG6pAZ4v4a2AW2v9afaw==",
       "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
-        "@remotion/media-parser": "4.0.489",
-        "@remotion/studio": "4.0.489",
-        "@remotion/studio-shared": "4.0.489",
-        "@remotion/timeline-utils": "4.0.489",
+        "@remotion/media-parser": "4.0.490",
+        "@remotion/studio": "4.0.490",
+        "@remotion/studio-shared": "4.0.490",
+        "@remotion/timeline-utils": "4.0.490",
         "@rspack/core": "1.7.11",
         "@rspack/plugin-react-refresh": "1.6.1",
         "css-loader": "7.1.4",
         "esbuild": "0.28.1",
         "react-refresh": "0.18.0",
-        "remotion": "4.0.489",
+        "remotion": "4.0.490",
         "style-loader": "4.0.0",
         "webpack": "5.105.0"
       },
@@ -1216,13 +1216,13 @@
       }
     },
     "node_modules/@remotion/canvas-capture": {
-      "version": "4.0.489",
-      "resolved": "https://registry.npmjs.org/@remotion/canvas-capture/-/canvas-capture-4.0.489.tgz",
-      "integrity": "sha512-A8ns99IFh8nPdrUbspXd9EcGbH+mKmCm9YmmMaxsjkywLGvEGggCCiRBnzHxIVtsoClxgUKZzIZ1ZQX1QCFrsg==",
+      "version": "4.0.490",
+      "resolved": "https://registry.npmjs.org/@remotion/canvas-capture/-/canvas-capture-4.0.490.tgz",
+      "integrity": "sha512-P9gCQ//7F0elQamT09eyoFobWsaHO0MMSqlA1ZAwy3IyL5/NQ1Rak8G7PJybucIuO0ISZxNF1Hkkb5tkWhfh4w==",
       "license": "Remotion License",
       "dependencies": {
         "mediabunny": "1.50.8",
-        "remotion": "4.0.489"
+        "remotion": "4.0.490"
       },
       "peerDependencies": {
         "react": ">=16.8.0",
@@ -1230,22 +1230,22 @@
       }
     },
     "node_modules/@remotion/cli": {
-      "version": "4.0.489",
-      "resolved": "https://registry.npmjs.org/@remotion/cli/-/cli-4.0.489.tgz",
-      "integrity": "sha512-8q4JHOpdu7LQPzZih65kyIRKjsMJwDM4cmpeNxk5bsty8E8a40nwwx8vrb9p0Gm1UJ7MJ9R8NvNuACKI2nj4hQ==",
+      "version": "4.0.490",
+      "resolved": "https://registry.npmjs.org/@remotion/cli/-/cli-4.0.490.tgz",
+      "integrity": "sha512-S9H/EqWVJNx9nQc7pFMsg2TT6JrPfy1M2RhcrvyIKvQOxP3cV3dy/FqOMtM1JSUo+jXQ9/tyX757QMBoUMwVnA==",
       "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
-        "@remotion/bundler": "4.0.489",
-        "@remotion/media-utils": "4.0.489",
-        "@remotion/player": "4.0.489",
-        "@remotion/renderer": "4.0.489",
-        "@remotion/studio": "4.0.489",
-        "@remotion/studio-server": "4.0.489",
-        "@remotion/studio-shared": "4.0.489",
+        "@remotion/bundler": "4.0.490",
+        "@remotion/media-utils": "4.0.490",
+        "@remotion/player": "4.0.490",
+        "@remotion/renderer": "4.0.490",
+        "@remotion/studio": "4.0.490",
+        "@remotion/studio-server": "4.0.490",
+        "@remotion/studio-shared": "4.0.490",
         "dotenv": "17.3.1",
         "minimist": "1.2.6",
         "prompts": "2.4.2",
-        "remotion": "4.0.489"
+        "remotion": "4.0.490"
       },
       "bin": {
         "remotion": "remotion-cli.js",
@@ -1258,9 +1258,9 @@
       }
     },
     "node_modules/@remotion/compositor-darwin-arm64": {
-      "version": "4.0.489",
-      "resolved": "https://registry.npmjs.org/@remotion/compositor-darwin-arm64/-/compositor-darwin-arm64-4.0.489.tgz",
-      "integrity": "sha512-ff9ifQXnqNtyBvUavq4g7DS8eV6E65vuYS4sU4d18PyMcVVhx9BtIfwerYDZ2bd0v/RqVTzsoNvTqjSAkSIQ8w==",
+      "version": "4.0.490",
+      "resolved": "https://registry.npmjs.org/@remotion/compositor-darwin-arm64/-/compositor-darwin-arm64-4.0.490.tgz",
+      "integrity": "sha512-llil+sp64oMTJvYBTpB7TuZkdpnhihmUzt44g5tQKTlS2KPN4LPMxXnQ+BiEz/4mEt8TnQhhZ3u13jJIdJyHcg==",
       "cpu": [
         "arm64"
       ],
@@ -1270,9 +1270,9 @@
       ]
     },
     "node_modules/@remotion/compositor-darwin-x64": {
-      "version": "4.0.489",
-      "resolved": "https://registry.npmjs.org/@remotion/compositor-darwin-x64/-/compositor-darwin-x64-4.0.489.tgz",
-      "integrity": "sha512-yq7yjrFS2OCgd8uxrEcZfSfexbw4nFMbExlnnFAOAgA9+dRnWGr68teySyQlHRduaxCTIjc0FQakziGuslatVw==",
+      "version": "4.0.490",
+      "resolved": "https://registry.npmjs.org/@remotion/compositor-darwin-x64/-/compositor-darwin-x64-4.0.490.tgz",
+      "integrity": "sha512-jpjZ8H6uCj2dW8JXViQGQXQoZ3iKy9041tjZKghPlLbgTh9G6eWdi8RmJ9W9+svI7Q3GTh6cjUQrQn/9pgpyMA==",
       "cpu": [
         "x64"
       ],
@@ -1282,9 +1282,9 @@
       ]
     },
     "node_modules/@remotion/compositor-linux-arm64-gnu": {
-      "version": "4.0.489",
-      "resolved": "https://registry.npmjs.org/@remotion/compositor-linux-arm64-gnu/-/compositor-linux-arm64-gnu-4.0.489.tgz",
-      "integrity": "sha512-fo6+5ER6B6WEejackegvagimU5Tgu1dGmI2iPOZomoRSFTXt4U4mPx1uDCwCEUPBteQQRxIVFFFTCRMHVm8MNg==",
+      "version": "4.0.490",
+      "resolved": "https://registry.npmjs.org/@remotion/compositor-linux-arm64-gnu/-/compositor-linux-arm64-gnu-4.0.490.tgz",
+      "integrity": "sha512-i0nffOg4gq3z/pbMvl++l92BgN2NHXIsZPm+E6s3ksC4ZuU8G5DGgqt4gVKIDijRJUCxTUbQ8DdR390dPhrkfg==",
       "cpu": [
         "arm64"
       ],
@@ -1294,9 +1294,9 @@
       ]
     },
     "node_modules/@remotion/compositor-linux-arm64-musl": {
-      "version": "4.0.489",
-      "resolved": "https://registry.npmjs.org/@remotion/compositor-linux-arm64-musl/-/compositor-linux-arm64-musl-4.0.489.tgz",
-      "integrity": "sha512-i6Wf9FdM8QBxhlawtxWTQ7194+VMSEaKSNCBcxR0PzvpKspfRSKF7PxF2cWgvi6KkzdxuFU+JO4A+TB+X8f/3Q==",
+      "version": "4.0.490",
+      "resolved": "https://registry.npmjs.org/@remotion/compositor-linux-arm64-musl/-/compositor-linux-arm64-musl-4.0.490.tgz",
+      "integrity": "sha512-xciEuhXb0NShigei+n8G0xrt/8g2jxmnSa6xQsIvwSee1kh1/fF4itpDKoi3pIMSUYkYMdN6GUdqqKXs16hkRw==",
       "cpu": [
         "arm64"
       ],
@@ -1306,9 +1306,9 @@
       ]
     },
     "node_modules/@remotion/compositor-linux-x64-gnu": {
-      "version": "4.0.489",
-      "resolved": "https://registry.npmjs.org/@remotion/compositor-linux-x64-gnu/-/compositor-linux-x64-gnu-4.0.489.tgz",
-      "integrity": "sha512-rr6tLuXps6ZWaUHK7Sk/MgyvBzBoMlin1jPuot7wvfBnyQwdSapZJT6ON1k+OxUEOHuYAPF38t50DGxsdJRy/g==",
+      "version": "4.0.490",
+      "resolved": "https://registry.npmjs.org/@remotion/compositor-linux-x64-gnu/-/compositor-linux-x64-gnu-4.0.490.tgz",
+      "integrity": "sha512-w5P9iP+xSp6xGIJJl5aw6d9vVrzyh5P9GOAKVzmrYHIoubgwBlQZVltq805n0kITqDpTjVcNHDrt5C8avZorJg==",
       "cpu": [
         "x64"
       ],
@@ -1318,9 +1318,9 @@
       ]
     },
     "node_modules/@remotion/compositor-linux-x64-musl": {
-      "version": "4.0.489",
-      "resolved": "https://registry.npmjs.org/@remotion/compositor-linux-x64-musl/-/compositor-linux-x64-musl-4.0.489.tgz",
-      "integrity": "sha512-U05hAlObEubkJi/MCCNzyyQn2wC5rkuiZWN07rzK4jNEqwP3L4dc24YRB8UlHg3XlrAOqqP3giOCAJ8skFDE4w==",
+      "version": "4.0.490",
+      "resolved": "https://registry.npmjs.org/@remotion/compositor-linux-x64-musl/-/compositor-linux-x64-musl-4.0.490.tgz",
+      "integrity": "sha512-wU8d3zhhWbHiQCssQPSj8fxp16adC0h/8PPiU+lqXvtokFYSt0Is+ya1NgUhRZc7THKg7RT5TVmRaV+qT/XaUA==",
       "cpu": [
         "x64"
       ],
@@ -1330,9 +1330,9 @@
       ]
     },
     "node_modules/@remotion/compositor-win32-x64-msvc": {
-      "version": "4.0.489",
-      "resolved": "https://registry.npmjs.org/@remotion/compositor-win32-x64-msvc/-/compositor-win32-x64-msvc-4.0.489.tgz",
-      "integrity": "sha512-NijrzGiOEriwW4N7wh/RzeDQyvecjI1Zwj4PoeDihJN9qCVlQSauBOqct6BwQb68XcLKFHFS2AWHH9y91NzNaQ==",
+      "version": "4.0.490",
+      "resolved": "https://registry.npmjs.org/@remotion/compositor-win32-x64-msvc/-/compositor-win32-x64-msvc-4.0.490.tgz",
+      "integrity": "sha512-k8bAJEiuVKJc1ZkJSmwm5g/pZOpQVXbVTVnCsnEjmsF+zbRoF6q71Ii8LuULxnOHBNLUSkfUg/Qlqh9YJ2FVOw==",
       "cpu": [
         "x64"
       ],
@@ -1342,25 +1342,25 @@
       ]
     },
     "node_modules/@remotion/licensing": {
-      "version": "4.0.489",
-      "resolved": "https://registry.npmjs.org/@remotion/licensing/-/licensing-4.0.489.tgz",
-      "integrity": "sha512-iEMhp4MRvjlkrXl8ZtrmsikcbXCzSGyk43s/NTLklsFHy+eBDSHO1rmmFrWPNZxw3pXwevdSbXZgyRh78X/3Ow==",
+      "version": "4.0.490",
+      "resolved": "https://registry.npmjs.org/@remotion/licensing/-/licensing-4.0.490.tgz",
+      "integrity": "sha512-p+h1JDnWYPIdIvMbMogAkV2Rt8w/5td5c9cyAwK1RUQYMq3PM/Wq6sncgqcWc3DQqWB3NJdmGhPNwSc5tt0KWg==",
       "license": "MIT"
     },
     "node_modules/@remotion/media-parser": {
-      "version": "4.0.489",
-      "resolved": "https://registry.npmjs.org/@remotion/media-parser/-/media-parser-4.0.489.tgz",
-      "integrity": "sha512-yIpGb7Bk7iKa/9MOHRfZM94N8GUOYqaOPEk8jt772hyroOxlgx2rKrMWXaN5mLCnJusWyM9ZQhCv4P2T/FlhhQ==",
+      "version": "4.0.490",
+      "resolved": "https://registry.npmjs.org/@remotion/media-parser/-/media-parser-4.0.490.tgz",
+      "integrity": "sha512-Dj64dV0YAh5DiTYyGTRexJNPqa+plCB7YOc/ij5bEBvJfvDAx2zWZtoUNLVjosmhyniHdK3GSB9fUJoLBFUJLw==",
       "license": "Remotion License https://remotion.dev/license"
     },
     "node_modules/@remotion/media-utils": {
-      "version": "4.0.489",
-      "resolved": "https://registry.npmjs.org/@remotion/media-utils/-/media-utils-4.0.489.tgz",
-      "integrity": "sha512-7cP8a7rRpOZ4+Cv+zeetnWWWmtLyt2Mf6xRvX8tconbfrV5yIxunY/4x4jgYdtvei/kKaWSa3I0j5RdLPS4/tA==",
+      "version": "4.0.490",
+      "resolved": "https://registry.npmjs.org/@remotion/media-utils/-/media-utils-4.0.490.tgz",
+      "integrity": "sha512-2bO0sSMfeSMlCKFaYggSXyLi8EjsCGdsOaE9c7SeWkCPpMiXSmnM+7eAWBrubEmjP4HMn9RFNJPlRX9MuXJlbA==",
       "license": "MIT",
       "dependencies": {
         "mediabunny": "1.50.8",
-        "remotion": "4.0.489"
+        "remotion": "4.0.490"
       },
       "peerDependencies": {
         "react": ">=16.8.0",
@@ -1368,12 +1368,12 @@
       }
     },
     "node_modules/@remotion/player": {
-      "version": "4.0.489",
-      "resolved": "https://registry.npmjs.org/@remotion/player/-/player-4.0.489.tgz",
-      "integrity": "sha512-DvnJiIbUpnoBlBJCpnsK0yRoR5X8iCumCFvmwVfk+ijSM6mX3W4DRa8xyg3m5B9EQi/L3V5JI+bH2hGQV43eOw==",
+      "version": "4.0.490",
+      "resolved": "https://registry.npmjs.org/@remotion/player/-/player-4.0.490.tgz",
+      "integrity": "sha512-HlxhVgYfxOBoIO1ovp/AO6lZhDx9SZO3Pfk+lZ1FdnWaKINe7MLspx9NvuYq12gY/KuBvAnBPoCF0AVkRvPwOQ==",
       "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
-        "remotion": "4.0.489"
+        "remotion": "4.0.490"
       },
       "peerDependencies": {
         "react": ">=16.8.0",
@@ -1381,26 +1381,26 @@
       }
     },
     "node_modules/@remotion/renderer": {
-      "version": "4.0.489",
-      "resolved": "https://registry.npmjs.org/@remotion/renderer/-/renderer-4.0.489.tgz",
-      "integrity": "sha512-ggaB6HLigaEOk6nJjafYZWJNCbV0iXZQ4XHnVSJjEtF6ebmkSbD+QAVe/jHI7BHudXKUJXWwLMQ8U417FajILw==",
+      "version": "4.0.490",
+      "resolved": "https://registry.npmjs.org/@remotion/renderer/-/renderer-4.0.490.tgz",
+      "integrity": "sha512-Kc4hZ+Sj/taDcSfQG2vTJ26Qu9B4hUCGK0//959GtCWObtb5mZDkFA9fnnD8+yb2Sm48tiNTtO1M2YZ376r2BA==",
       "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
-        "@remotion/licensing": "4.0.489",
-        "@remotion/streaming": "4.0.489",
+        "@remotion/licensing": "4.0.490",
+        "@remotion/streaming": "4.0.490",
         "execa": "5.1.1",
-        "remotion": "4.0.489",
+        "remotion": "4.0.490",
         "source-map": "0.8.0-beta.0",
         "ws": "8.21.0"
       },
       "optionalDependencies": {
-        "@remotion/compositor-darwin-arm64": "4.0.489",
-        "@remotion/compositor-darwin-x64": "4.0.489",
-        "@remotion/compositor-linux-arm64-gnu": "4.0.489",
-        "@remotion/compositor-linux-arm64-musl": "4.0.489",
-        "@remotion/compositor-linux-x64-gnu": "4.0.489",
-        "@remotion/compositor-linux-x64-musl": "4.0.489",
-        "@remotion/compositor-win32-x64-msvc": "4.0.489"
+        "@remotion/compositor-darwin-arm64": "4.0.490",
+        "@remotion/compositor-darwin-x64": "4.0.490",
+        "@remotion/compositor-linux-arm64-gnu": "4.0.490",
+        "@remotion/compositor-linux-arm64-musl": "4.0.490",
+        "@remotion/compositor-linux-x64-gnu": "4.0.490",
+        "@remotion/compositor-linux-x64-musl": "4.0.490",
+        "@remotion/compositor-win32-x64-msvc": "4.0.490"
       },
       "peerDependencies": {
         "react": ">=16.8.0",
@@ -1408,30 +1408,30 @@
       }
     },
     "node_modules/@remotion/streaming": {
-      "version": "4.0.489",
-      "resolved": "https://registry.npmjs.org/@remotion/streaming/-/streaming-4.0.489.tgz",
-      "integrity": "sha512-PH3NFiuyotZCXA2yoNQ2VwqWuNwWkzEFdNCihdj4s5xO41oF+aPEjD8EwJKNd60TKG5ICj/3W3HJkWkywFFoeA==",
+      "version": "4.0.490",
+      "resolved": "https://registry.npmjs.org/@remotion/streaming/-/streaming-4.0.490.tgz",
+      "integrity": "sha512-q4LuNxkGlLg6iEdOUTKVMCsvIdl6ZcMzVMWBuasrhZ8DnceCPr7Xzy2qaeNxAGhk14I8xIDHbFRylwJ8vOHCoA==",
       "license": "MIT"
     },
     "node_modules/@remotion/studio": {
-      "version": "4.0.489",
-      "resolved": "https://registry.npmjs.org/@remotion/studio/-/studio-4.0.489.tgz",
-      "integrity": "sha512-nihkSBSOY4MSyVbk8WDTbqmqa5D2yNveqmCsmDJPmGWL7omqL1IEsy5Vynd584cR24fqFNuYrsxuOLJ2o1prbw==",
+      "version": "4.0.490",
+      "resolved": "https://registry.npmjs.org/@remotion/studio/-/studio-4.0.490.tgz",
+      "integrity": "sha512-JY6Oln9hD/JcSTax4AIuiEQ5ZPsE4Rp8UHJHdcClETDvmIXPQPyYmVYYGMuLL/3kgwCzhzCdKFiwvLgre1p8AA==",
       "license": "MIT",
       "dependencies": {
         "@jridgewell/trace-mapping": "0.3.31",
-        "@remotion/canvas-capture": "4.0.489",
-        "@remotion/media-utils": "4.0.489",
-        "@remotion/player": "4.0.489",
-        "@remotion/renderer": "4.0.489",
-        "@remotion/studio-shared": "4.0.489",
-        "@remotion/timeline-utils": "4.0.489",
-        "@remotion/web-renderer": "4.0.489",
-        "@remotion/zod-types": "4.0.489",
+        "@remotion/canvas-capture": "4.0.490",
+        "@remotion/media-utils": "4.0.490",
+        "@remotion/player": "4.0.490",
+        "@remotion/renderer": "4.0.490",
+        "@remotion/studio-shared": "4.0.490",
+        "@remotion/timeline-utils": "4.0.490",
+        "@remotion/web-renderer": "4.0.490",
+        "@remotion/zod-types": "4.0.490",
         "mediabunny": "1.50.8",
         "memfs": "3.4.3",
         "open": "8.4.2",
-        "remotion": "4.0.489",
+        "remotion": "4.0.490",
         "semver": "7.5.3",
         "zod": "4.3.6"
       },
@@ -1441,54 +1441,54 @@
       }
     },
     "node_modules/@remotion/studio-server": {
-      "version": "4.0.489",
-      "resolved": "https://registry.npmjs.org/@remotion/studio-server/-/studio-server-4.0.489.tgz",
-      "integrity": "sha512-iLdYfY2gtE+Nvs3qSNfFapNEXa0hEIHTTxtyH7l4ENmoTIXzzACn4rrkV2iXqFfD0QEZmjbqpJSOg4yO8QCQKw==",
+      "version": "4.0.490",
+      "resolved": "https://registry.npmjs.org/@remotion/studio-server/-/studio-server-4.0.490.tgz",
+      "integrity": "sha512-QxYQ43Tp5iL4P7y/NBRGj5LCWY0FO4Lpn2eyNflNw1uZySxBayeoyiLhv1YG66GRMWnMzIgjj/2tWVXXlidOig==",
       "license": "MIT",
       "dependencies": {
         "@babel/parser": "7.24.1",
         "@babel/types": "7.24.0",
-        "@remotion/bundler": "4.0.489",
-        "@remotion/renderer": "4.0.489",
-        "@remotion/studio-shared": "4.0.489",
+        "@remotion/bundler": "4.0.490",
+        "@remotion/renderer": "4.0.490",
+        "@remotion/studio-shared": "4.0.490",
         "memfs": "3.4.3",
         "open": "8.4.2",
         "prettier": "3.8.1",
         "recast": "0.23.11",
-        "remotion": "4.0.489",
+        "remotion": "4.0.490",
         "semver": "7.5.3"
       }
     },
     "node_modules/@remotion/studio-shared": {
-      "version": "4.0.489",
-      "resolved": "https://registry.npmjs.org/@remotion/studio-shared/-/studio-shared-4.0.489.tgz",
-      "integrity": "sha512-Pjfd0XrH/wtjXb4IJIJ8gLjAGbhnZPLYfwp8aWrBteghqKFyBM2BNFk1u/g5RvEN5sNL/zwE/bBBNATSuX8PHQ==",
+      "version": "4.0.490",
+      "resolved": "https://registry.npmjs.org/@remotion/studio-shared/-/studio-shared-4.0.490.tgz",
+      "integrity": "sha512-z84S704IEB8VIGnr6pZGH8XJFsrQD5fr8D5KqCXYqK6/KXW0qgv7965v3hlXhhCcD5rLfdoP8UdQHRpZolTlqw==",
       "license": "MIT",
       "dependencies": {
-        "remotion": "4.0.489"
+        "remotion": "4.0.490"
       }
     },
     "node_modules/@remotion/timeline-utils": {
-      "version": "4.0.489",
-      "resolved": "https://registry.npmjs.org/@remotion/timeline-utils/-/timeline-utils-4.0.489.tgz",
-      "integrity": "sha512-5VhndeYJY0muffx6GU6rB7eXIKntYBKsgTfuISj3/ugH+CwT6+943XYMgUPh+/LS4/DOqt+VhR6SB9FSKv8eGQ==",
+      "version": "4.0.490",
+      "resolved": "https://registry.npmjs.org/@remotion/timeline-utils/-/timeline-utils-4.0.490.tgz",
+      "integrity": "sha512-thYL+XEe6sE0xs61tpeKfCJY4jFvXhtjLa2n9pDnihSGVdvSQ5wUwbDmunQMPZvAvbiEBA8SaMrQzupF9L2BrA==",
       "license": "MIT",
       "dependencies": {
         "mediabunny": "1.50.8"
       }
     },
     "node_modules/@remotion/web-renderer": {
-      "version": "4.0.489",
-      "resolved": "https://registry.npmjs.org/@remotion/web-renderer/-/web-renderer-4.0.489.tgz",
-      "integrity": "sha512-owkisp0rbeo2tcOKKdECFnktI4rO9K7CZ/sMFWmdgYTgma5uNIS1vosMZCyE0/ZqCNA2fwNcj/zpcEpadNhfdw==",
+      "version": "4.0.490",
+      "resolved": "https://registry.npmjs.org/@remotion/web-renderer/-/web-renderer-4.0.490.tgz",
+      "integrity": "sha512-LXETwo5svXVba/MLafS8bgNxz0yrL4e85zXDFIicIsqudfOpdb9osmmqFTAima2Uw8U+k+U7k/lGeHj82qXOjg==",
       "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
         "@mediabunny/aac-encoder": "1.50.8",
         "@mediabunny/flac-encoder": "1.50.8",
         "@mediabunny/mp3-encoder": "1.50.8",
-        "@remotion/licensing": "4.0.489",
+        "@remotion/licensing": "4.0.490",
         "mediabunny": "1.50.8",
-        "remotion": "4.0.489"
+        "remotion": "4.0.490"
       },
       "peerDependencies": {
         "react": ">=18.0.0",
@@ -1496,12 +1496,12 @@
       }
     },
     "node_modules/@remotion/zod-types": {
-      "version": "4.0.489",
-      "resolved": "https://registry.npmjs.org/@remotion/zod-types/-/zod-types-4.0.489.tgz",
-      "integrity": "sha512-Il0R4O07OsaiTUDIP88owfvKyEz8wWLkSnl9UODCgTs6f9h5I/lTe+GImN2aj9cObt9S1IUFfjd0/+0AbgVjEg==",
+      "version": "4.0.490",
+      "resolved": "https://registry.npmjs.org/@remotion/zod-types/-/zod-types-4.0.490.tgz",
+      "integrity": "sha512-4xJaX+nBW14Nt9rhvTan/XTryChEfrbN1mmxVjtulrk8vxvtPmCvKRJ8kdyION2vgCNG4sza8rfFoButa9b/DQ==",
       "license": "MIT",
       "dependencies": {
-        "remotion": "4.0.489"
+        "remotion": "4.0.490"
       }
     },
     "node_modules/@rspack/binding": {
@@ -2076,9 +2076,9 @@
       "license": "MIT"
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001805",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001805.tgz",
-      "integrity": "sha512-52noaS3DubycKSXaU30TwPGIp+POyQSUVa5jBEq3vkRkY0kjyb3LQgvhU6WGyCcyXqVLWO0Cw0Q6BSdD0kUfVA==",
+      "version": "1.0.30001806",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001806.tgz",
+      "integrity": "sha512-72Cuvd95zbSYPKq6Fhg8eDJRlzgWDf7/mtoZv6Qe/DYNCEBdNxoA3+rZAU2ZhGCpZlns3EssFavaZomckT5Uuw==",
       "funding": [
         {
           "type": "opencollective",
@@ -2222,9 +2222,9 @@
       }
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.5.392",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.392.tgz",
-      "integrity": "sha512-1yQq3VQCZRwsnYc67Oc+1fge6Lwtn0hzi6zmEVkB61Zx21kTbwJAW4dFLadl5Rc1tKhG/kSpYXnfiAhu0f0a1g==",
+      "version": "1.5.393",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.393.tgz",
+      "integrity": "sha512-kiDJdIUawuEIcp9XoICKp1iTYDEbgguIPq526N1Q7jIQDeQ3CqoMx71025PI/7E48Ddtw2HuWsVjY7afEgNxmg==",
       "license": "ISC"
     },
     "node_modules/enhanced-resolve": {
@@ -2965,9 +2965,9 @@
       }
     },
     "node_modules/remotion": {
-      "version": "4.0.489",
-      "resolved": "https://registry.npmjs.org/remotion/-/remotion-4.0.489.tgz",
-      "integrity": "sha512-r7VBcWKqsGjaXT6Iv6XNFrzsZl45JvLOi6WmMYMN1zkpCoo0sm9xoi8g2pLF2Y9D7EBgygXFaG4DjjaKOVcPSg==",
+      "version": "4.0.490",
+      "resolved": "https://registry.npmjs.org/remotion/-/remotion-4.0.490.tgz",
+      "integrity": "sha512-acyJNHljJvH7+I9kXJAK5bVVN7FAyM3tILGhnwZKJoB27Xp2WQ3cMyGIh8XFwlR66/ZESWkw74s49GItHejOWQ==",
       "license": "SEE LICENSE IN LICENSE.md",
       "peerDependencies": {
         "react": ">=16.8.0",

--- a/package.json
+++ b/package.json
@@ -55,10 +55,10 @@
     "test": "node --test tests/*.test.mjs"
   },
   "dependencies": {
-    "@remotion/cli": "4.0.489",
+    "@remotion/cli": "4.0.490",
     "react": "19.2.7",
     "react-dom": "19.2.7",
-    "remotion": "4.0.489"
+    "remotion": "4.0.490"
   },
   "devDependencies": {
     "@types/react": "19.2.17",

--- a/plugins/paper-collage-video/assets/remotion-template/package-lock.json
+++ b/plugins/paper-collage-video/assets/remotion-template/package-lock.json
@@ -8,20 +8,20 @@
       "name": "paper-collage-video-workspace",
       "version": "0.4.0",
       "license": "MIT",
-      "engines": {
-        "node": ">=20"
-      },
       "dependencies": {
-        "@remotion/cli": "4.0.489",
+        "@remotion/cli": "4.0.490",
         "react": "19.2.7",
         "react-dom": "19.2.7",
-        "remotion": "4.0.489"
+        "remotion": "4.0.490"
       },
       "devDependencies": {
         "@types/react": "19.2.17",
         "@types/react-dom": "19.2.3",
         "sharp": "0.35.3",
         "typescript": "5.9.3"
+      },
+      "engines": {
+        "node": ">=20"
       }
     },
     "node_modules/@babel/helper-string-parser": {
@@ -1192,21 +1192,21 @@
       }
     },
     "node_modules/@remotion/bundler": {
-      "version": "4.0.489",
-      "resolved": "https://registry.npmjs.org/@remotion/bundler/-/bundler-4.0.489.tgz",
-      "integrity": "sha512-f2uLJfo3Ar3YiW32aiEdf7JTJgnMQEjdMLSdIaf/8GSktJ5yfqKxjL9mIRfIaYiRVjp99jCzcb2I4yqDwIbfNg==",
+      "version": "4.0.490",
+      "resolved": "https://registry.npmjs.org/@remotion/bundler/-/bundler-4.0.490.tgz",
+      "integrity": "sha512-AZe7ncD+b0OUap5ZT8T0boONa7+I7Ap4+kAh5BZOa5sVaBjz4YI7eqILXtGqi+kNuBsG6pAZ4v4a2AW2v9afaw==",
       "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
-        "@remotion/media-parser": "4.0.489",
-        "@remotion/studio": "4.0.489",
-        "@remotion/studio-shared": "4.0.489",
-        "@remotion/timeline-utils": "4.0.489",
+        "@remotion/media-parser": "4.0.490",
+        "@remotion/studio": "4.0.490",
+        "@remotion/studio-shared": "4.0.490",
+        "@remotion/timeline-utils": "4.0.490",
         "@rspack/core": "1.7.11",
         "@rspack/plugin-react-refresh": "1.6.1",
         "css-loader": "7.1.4",
         "esbuild": "0.28.1",
         "react-refresh": "0.18.0",
-        "remotion": "4.0.489",
+        "remotion": "4.0.490",
         "style-loader": "4.0.0",
         "webpack": "5.105.0"
       },
@@ -1216,13 +1216,13 @@
       }
     },
     "node_modules/@remotion/canvas-capture": {
-      "version": "4.0.489",
-      "resolved": "https://registry.npmjs.org/@remotion/canvas-capture/-/canvas-capture-4.0.489.tgz",
-      "integrity": "sha512-A8ns99IFh8nPdrUbspXd9EcGbH+mKmCm9YmmMaxsjkywLGvEGggCCiRBnzHxIVtsoClxgUKZzIZ1ZQX1QCFrsg==",
+      "version": "4.0.490",
+      "resolved": "https://registry.npmjs.org/@remotion/canvas-capture/-/canvas-capture-4.0.490.tgz",
+      "integrity": "sha512-P9gCQ//7F0elQamT09eyoFobWsaHO0MMSqlA1ZAwy3IyL5/NQ1Rak8G7PJybucIuO0ISZxNF1Hkkb5tkWhfh4w==",
       "license": "Remotion License",
       "dependencies": {
         "mediabunny": "1.50.8",
-        "remotion": "4.0.489"
+        "remotion": "4.0.490"
       },
       "peerDependencies": {
         "react": ">=16.8.0",
@@ -1230,22 +1230,22 @@
       }
     },
     "node_modules/@remotion/cli": {
-      "version": "4.0.489",
-      "resolved": "https://registry.npmjs.org/@remotion/cli/-/cli-4.0.489.tgz",
-      "integrity": "sha512-8q4JHOpdu7LQPzZih65kyIRKjsMJwDM4cmpeNxk5bsty8E8a40nwwx8vrb9p0Gm1UJ7MJ9R8NvNuACKI2nj4hQ==",
+      "version": "4.0.490",
+      "resolved": "https://registry.npmjs.org/@remotion/cli/-/cli-4.0.490.tgz",
+      "integrity": "sha512-S9H/EqWVJNx9nQc7pFMsg2TT6JrPfy1M2RhcrvyIKvQOxP3cV3dy/FqOMtM1JSUo+jXQ9/tyX757QMBoUMwVnA==",
       "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
-        "@remotion/bundler": "4.0.489",
-        "@remotion/media-utils": "4.0.489",
-        "@remotion/player": "4.0.489",
-        "@remotion/renderer": "4.0.489",
-        "@remotion/studio": "4.0.489",
-        "@remotion/studio-server": "4.0.489",
-        "@remotion/studio-shared": "4.0.489",
+        "@remotion/bundler": "4.0.490",
+        "@remotion/media-utils": "4.0.490",
+        "@remotion/player": "4.0.490",
+        "@remotion/renderer": "4.0.490",
+        "@remotion/studio": "4.0.490",
+        "@remotion/studio-server": "4.0.490",
+        "@remotion/studio-shared": "4.0.490",
         "dotenv": "17.3.1",
         "minimist": "1.2.6",
         "prompts": "2.4.2",
-        "remotion": "4.0.489"
+        "remotion": "4.0.490"
       },
       "bin": {
         "remotion": "remotion-cli.js",
@@ -1258,9 +1258,9 @@
       }
     },
     "node_modules/@remotion/compositor-darwin-arm64": {
-      "version": "4.0.489",
-      "resolved": "https://registry.npmjs.org/@remotion/compositor-darwin-arm64/-/compositor-darwin-arm64-4.0.489.tgz",
-      "integrity": "sha512-ff9ifQXnqNtyBvUavq4g7DS8eV6E65vuYS4sU4d18PyMcVVhx9BtIfwerYDZ2bd0v/RqVTzsoNvTqjSAkSIQ8w==",
+      "version": "4.0.490",
+      "resolved": "https://registry.npmjs.org/@remotion/compositor-darwin-arm64/-/compositor-darwin-arm64-4.0.490.tgz",
+      "integrity": "sha512-llil+sp64oMTJvYBTpB7TuZkdpnhihmUzt44g5tQKTlS2KPN4LPMxXnQ+BiEz/4mEt8TnQhhZ3u13jJIdJyHcg==",
       "cpu": [
         "arm64"
       ],
@@ -1270,9 +1270,9 @@
       ]
     },
     "node_modules/@remotion/compositor-darwin-x64": {
-      "version": "4.0.489",
-      "resolved": "https://registry.npmjs.org/@remotion/compositor-darwin-x64/-/compositor-darwin-x64-4.0.489.tgz",
-      "integrity": "sha512-yq7yjrFS2OCgd8uxrEcZfSfexbw4nFMbExlnnFAOAgA9+dRnWGr68teySyQlHRduaxCTIjc0FQakziGuslatVw==",
+      "version": "4.0.490",
+      "resolved": "https://registry.npmjs.org/@remotion/compositor-darwin-x64/-/compositor-darwin-x64-4.0.490.tgz",
+      "integrity": "sha512-jpjZ8H6uCj2dW8JXViQGQXQoZ3iKy9041tjZKghPlLbgTh9G6eWdi8RmJ9W9+svI7Q3GTh6cjUQrQn/9pgpyMA==",
       "cpu": [
         "x64"
       ],
@@ -1282,9 +1282,9 @@
       ]
     },
     "node_modules/@remotion/compositor-linux-arm64-gnu": {
-      "version": "4.0.489",
-      "resolved": "https://registry.npmjs.org/@remotion/compositor-linux-arm64-gnu/-/compositor-linux-arm64-gnu-4.0.489.tgz",
-      "integrity": "sha512-fo6+5ER6B6WEejackegvagimU5Tgu1dGmI2iPOZomoRSFTXt4U4mPx1uDCwCEUPBteQQRxIVFFFTCRMHVm8MNg==",
+      "version": "4.0.490",
+      "resolved": "https://registry.npmjs.org/@remotion/compositor-linux-arm64-gnu/-/compositor-linux-arm64-gnu-4.0.490.tgz",
+      "integrity": "sha512-i0nffOg4gq3z/pbMvl++l92BgN2NHXIsZPm+E6s3ksC4ZuU8G5DGgqt4gVKIDijRJUCxTUbQ8DdR390dPhrkfg==",
       "cpu": [
         "arm64"
       ],
@@ -1294,9 +1294,9 @@
       ]
     },
     "node_modules/@remotion/compositor-linux-arm64-musl": {
-      "version": "4.0.489",
-      "resolved": "https://registry.npmjs.org/@remotion/compositor-linux-arm64-musl/-/compositor-linux-arm64-musl-4.0.489.tgz",
-      "integrity": "sha512-i6Wf9FdM8QBxhlawtxWTQ7194+VMSEaKSNCBcxR0PzvpKspfRSKF7PxF2cWgvi6KkzdxuFU+JO4A+TB+X8f/3Q==",
+      "version": "4.0.490",
+      "resolved": "https://registry.npmjs.org/@remotion/compositor-linux-arm64-musl/-/compositor-linux-arm64-musl-4.0.490.tgz",
+      "integrity": "sha512-xciEuhXb0NShigei+n8G0xrt/8g2jxmnSa6xQsIvwSee1kh1/fF4itpDKoi3pIMSUYkYMdN6GUdqqKXs16hkRw==",
       "cpu": [
         "arm64"
       ],
@@ -1306,9 +1306,9 @@
       ]
     },
     "node_modules/@remotion/compositor-linux-x64-gnu": {
-      "version": "4.0.489",
-      "resolved": "https://registry.npmjs.org/@remotion/compositor-linux-x64-gnu/-/compositor-linux-x64-gnu-4.0.489.tgz",
-      "integrity": "sha512-rr6tLuXps6ZWaUHK7Sk/MgyvBzBoMlin1jPuot7wvfBnyQwdSapZJT6ON1k+OxUEOHuYAPF38t50DGxsdJRy/g==",
+      "version": "4.0.490",
+      "resolved": "https://registry.npmjs.org/@remotion/compositor-linux-x64-gnu/-/compositor-linux-x64-gnu-4.0.490.tgz",
+      "integrity": "sha512-w5P9iP+xSp6xGIJJl5aw6d9vVrzyh5P9GOAKVzmrYHIoubgwBlQZVltq805n0kITqDpTjVcNHDrt5C8avZorJg==",
       "cpu": [
         "x64"
       ],
@@ -1318,9 +1318,9 @@
       ]
     },
     "node_modules/@remotion/compositor-linux-x64-musl": {
-      "version": "4.0.489",
-      "resolved": "https://registry.npmjs.org/@remotion/compositor-linux-x64-musl/-/compositor-linux-x64-musl-4.0.489.tgz",
-      "integrity": "sha512-U05hAlObEubkJi/MCCNzyyQn2wC5rkuiZWN07rzK4jNEqwP3L4dc24YRB8UlHg3XlrAOqqP3giOCAJ8skFDE4w==",
+      "version": "4.0.490",
+      "resolved": "https://registry.npmjs.org/@remotion/compositor-linux-x64-musl/-/compositor-linux-x64-musl-4.0.490.tgz",
+      "integrity": "sha512-wU8d3zhhWbHiQCssQPSj8fxp16adC0h/8PPiU+lqXvtokFYSt0Is+ya1NgUhRZc7THKg7RT5TVmRaV+qT/XaUA==",
       "cpu": [
         "x64"
       ],
@@ -1330,9 +1330,9 @@
       ]
     },
     "node_modules/@remotion/compositor-win32-x64-msvc": {
-      "version": "4.0.489",
-      "resolved": "https://registry.npmjs.org/@remotion/compositor-win32-x64-msvc/-/compositor-win32-x64-msvc-4.0.489.tgz",
-      "integrity": "sha512-NijrzGiOEriwW4N7wh/RzeDQyvecjI1Zwj4PoeDihJN9qCVlQSauBOqct6BwQb68XcLKFHFS2AWHH9y91NzNaQ==",
+      "version": "4.0.490",
+      "resolved": "https://registry.npmjs.org/@remotion/compositor-win32-x64-msvc/-/compositor-win32-x64-msvc-4.0.490.tgz",
+      "integrity": "sha512-k8bAJEiuVKJc1ZkJSmwm5g/pZOpQVXbVTVnCsnEjmsF+zbRoF6q71Ii8LuULxnOHBNLUSkfUg/Qlqh9YJ2FVOw==",
       "cpu": [
         "x64"
       ],
@@ -1342,25 +1342,25 @@
       ]
     },
     "node_modules/@remotion/licensing": {
-      "version": "4.0.489",
-      "resolved": "https://registry.npmjs.org/@remotion/licensing/-/licensing-4.0.489.tgz",
-      "integrity": "sha512-iEMhp4MRvjlkrXl8ZtrmsikcbXCzSGyk43s/NTLklsFHy+eBDSHO1rmmFrWPNZxw3pXwevdSbXZgyRh78X/3Ow==",
+      "version": "4.0.490",
+      "resolved": "https://registry.npmjs.org/@remotion/licensing/-/licensing-4.0.490.tgz",
+      "integrity": "sha512-p+h1JDnWYPIdIvMbMogAkV2Rt8w/5td5c9cyAwK1RUQYMq3PM/Wq6sncgqcWc3DQqWB3NJdmGhPNwSc5tt0KWg==",
       "license": "MIT"
     },
     "node_modules/@remotion/media-parser": {
-      "version": "4.0.489",
-      "resolved": "https://registry.npmjs.org/@remotion/media-parser/-/media-parser-4.0.489.tgz",
-      "integrity": "sha512-yIpGb7Bk7iKa/9MOHRfZM94N8GUOYqaOPEk8jt772hyroOxlgx2rKrMWXaN5mLCnJusWyM9ZQhCv4P2T/FlhhQ==",
+      "version": "4.0.490",
+      "resolved": "https://registry.npmjs.org/@remotion/media-parser/-/media-parser-4.0.490.tgz",
+      "integrity": "sha512-Dj64dV0YAh5DiTYyGTRexJNPqa+plCB7YOc/ij5bEBvJfvDAx2zWZtoUNLVjosmhyniHdK3GSB9fUJoLBFUJLw==",
       "license": "Remotion License https://remotion.dev/license"
     },
     "node_modules/@remotion/media-utils": {
-      "version": "4.0.489",
-      "resolved": "https://registry.npmjs.org/@remotion/media-utils/-/media-utils-4.0.489.tgz",
-      "integrity": "sha512-7cP8a7rRpOZ4+Cv+zeetnWWWmtLyt2Mf6xRvX8tconbfrV5yIxunY/4x4jgYdtvei/kKaWSa3I0j5RdLPS4/tA==",
+      "version": "4.0.490",
+      "resolved": "https://registry.npmjs.org/@remotion/media-utils/-/media-utils-4.0.490.tgz",
+      "integrity": "sha512-2bO0sSMfeSMlCKFaYggSXyLi8EjsCGdsOaE9c7SeWkCPpMiXSmnM+7eAWBrubEmjP4HMn9RFNJPlRX9MuXJlbA==",
       "license": "MIT",
       "dependencies": {
         "mediabunny": "1.50.8",
-        "remotion": "4.0.489"
+        "remotion": "4.0.490"
       },
       "peerDependencies": {
         "react": ">=16.8.0",
@@ -1368,12 +1368,12 @@
       }
     },
     "node_modules/@remotion/player": {
-      "version": "4.0.489",
-      "resolved": "https://registry.npmjs.org/@remotion/player/-/player-4.0.489.tgz",
-      "integrity": "sha512-DvnJiIbUpnoBlBJCpnsK0yRoR5X8iCumCFvmwVfk+ijSM6mX3W4DRa8xyg3m5B9EQi/L3V5JI+bH2hGQV43eOw==",
+      "version": "4.0.490",
+      "resolved": "https://registry.npmjs.org/@remotion/player/-/player-4.0.490.tgz",
+      "integrity": "sha512-HlxhVgYfxOBoIO1ovp/AO6lZhDx9SZO3Pfk+lZ1FdnWaKINe7MLspx9NvuYq12gY/KuBvAnBPoCF0AVkRvPwOQ==",
       "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
-        "remotion": "4.0.489"
+        "remotion": "4.0.490"
       },
       "peerDependencies": {
         "react": ">=16.8.0",
@@ -1381,26 +1381,26 @@
       }
     },
     "node_modules/@remotion/renderer": {
-      "version": "4.0.489",
-      "resolved": "https://registry.npmjs.org/@remotion/renderer/-/renderer-4.0.489.tgz",
-      "integrity": "sha512-ggaB6HLigaEOk6nJjafYZWJNCbV0iXZQ4XHnVSJjEtF6ebmkSbD+QAVe/jHI7BHudXKUJXWwLMQ8U417FajILw==",
+      "version": "4.0.490",
+      "resolved": "https://registry.npmjs.org/@remotion/renderer/-/renderer-4.0.490.tgz",
+      "integrity": "sha512-Kc4hZ+Sj/taDcSfQG2vTJ26Qu9B4hUCGK0//959GtCWObtb5mZDkFA9fnnD8+yb2Sm48tiNTtO1M2YZ376r2BA==",
       "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
-        "@remotion/licensing": "4.0.489",
-        "@remotion/streaming": "4.0.489",
+        "@remotion/licensing": "4.0.490",
+        "@remotion/streaming": "4.0.490",
         "execa": "5.1.1",
-        "remotion": "4.0.489",
+        "remotion": "4.0.490",
         "source-map": "0.8.0-beta.0",
         "ws": "8.21.0"
       },
       "optionalDependencies": {
-        "@remotion/compositor-darwin-arm64": "4.0.489",
-        "@remotion/compositor-darwin-x64": "4.0.489",
-        "@remotion/compositor-linux-arm64-gnu": "4.0.489",
-        "@remotion/compositor-linux-arm64-musl": "4.0.489",
-        "@remotion/compositor-linux-x64-gnu": "4.0.489",
-        "@remotion/compositor-linux-x64-musl": "4.0.489",
-        "@remotion/compositor-win32-x64-msvc": "4.0.489"
+        "@remotion/compositor-darwin-arm64": "4.0.490",
+        "@remotion/compositor-darwin-x64": "4.0.490",
+        "@remotion/compositor-linux-arm64-gnu": "4.0.490",
+        "@remotion/compositor-linux-arm64-musl": "4.0.490",
+        "@remotion/compositor-linux-x64-gnu": "4.0.490",
+        "@remotion/compositor-linux-x64-musl": "4.0.490",
+        "@remotion/compositor-win32-x64-msvc": "4.0.490"
       },
       "peerDependencies": {
         "react": ">=16.8.0",
@@ -1408,30 +1408,30 @@
       }
     },
     "node_modules/@remotion/streaming": {
-      "version": "4.0.489",
-      "resolved": "https://registry.npmjs.org/@remotion/streaming/-/streaming-4.0.489.tgz",
-      "integrity": "sha512-PH3NFiuyotZCXA2yoNQ2VwqWuNwWkzEFdNCihdj4s5xO41oF+aPEjD8EwJKNd60TKG5ICj/3W3HJkWkywFFoeA==",
+      "version": "4.0.490",
+      "resolved": "https://registry.npmjs.org/@remotion/streaming/-/streaming-4.0.490.tgz",
+      "integrity": "sha512-q4LuNxkGlLg6iEdOUTKVMCsvIdl6ZcMzVMWBuasrhZ8DnceCPr7Xzy2qaeNxAGhk14I8xIDHbFRylwJ8vOHCoA==",
       "license": "MIT"
     },
     "node_modules/@remotion/studio": {
-      "version": "4.0.489",
-      "resolved": "https://registry.npmjs.org/@remotion/studio/-/studio-4.0.489.tgz",
-      "integrity": "sha512-nihkSBSOY4MSyVbk8WDTbqmqa5D2yNveqmCsmDJPmGWL7omqL1IEsy5Vynd584cR24fqFNuYrsxuOLJ2o1prbw==",
+      "version": "4.0.490",
+      "resolved": "https://registry.npmjs.org/@remotion/studio/-/studio-4.0.490.tgz",
+      "integrity": "sha512-JY6Oln9hD/JcSTax4AIuiEQ5ZPsE4Rp8UHJHdcClETDvmIXPQPyYmVYYGMuLL/3kgwCzhzCdKFiwvLgre1p8AA==",
       "license": "MIT",
       "dependencies": {
         "@jridgewell/trace-mapping": "0.3.31",
-        "@remotion/canvas-capture": "4.0.489",
-        "@remotion/media-utils": "4.0.489",
-        "@remotion/player": "4.0.489",
-        "@remotion/renderer": "4.0.489",
-        "@remotion/studio-shared": "4.0.489",
-        "@remotion/timeline-utils": "4.0.489",
-        "@remotion/web-renderer": "4.0.489",
-        "@remotion/zod-types": "4.0.489",
+        "@remotion/canvas-capture": "4.0.490",
+        "@remotion/media-utils": "4.0.490",
+        "@remotion/player": "4.0.490",
+        "@remotion/renderer": "4.0.490",
+        "@remotion/studio-shared": "4.0.490",
+        "@remotion/timeline-utils": "4.0.490",
+        "@remotion/web-renderer": "4.0.490",
+        "@remotion/zod-types": "4.0.490",
         "mediabunny": "1.50.8",
         "memfs": "3.4.3",
         "open": "8.4.2",
-        "remotion": "4.0.489",
+        "remotion": "4.0.490",
         "semver": "7.5.3",
         "zod": "4.3.6"
       },
@@ -1441,54 +1441,54 @@
       }
     },
     "node_modules/@remotion/studio-server": {
-      "version": "4.0.489",
-      "resolved": "https://registry.npmjs.org/@remotion/studio-server/-/studio-server-4.0.489.tgz",
-      "integrity": "sha512-iLdYfY2gtE+Nvs3qSNfFapNEXa0hEIHTTxtyH7l4ENmoTIXzzACn4rrkV2iXqFfD0QEZmjbqpJSOg4yO8QCQKw==",
+      "version": "4.0.490",
+      "resolved": "https://registry.npmjs.org/@remotion/studio-server/-/studio-server-4.0.490.tgz",
+      "integrity": "sha512-QxYQ43Tp5iL4P7y/NBRGj5LCWY0FO4Lpn2eyNflNw1uZySxBayeoyiLhv1YG66GRMWnMzIgjj/2tWVXXlidOig==",
       "license": "MIT",
       "dependencies": {
         "@babel/parser": "7.24.1",
         "@babel/types": "7.24.0",
-        "@remotion/bundler": "4.0.489",
-        "@remotion/renderer": "4.0.489",
-        "@remotion/studio-shared": "4.0.489",
+        "@remotion/bundler": "4.0.490",
+        "@remotion/renderer": "4.0.490",
+        "@remotion/studio-shared": "4.0.490",
         "memfs": "3.4.3",
         "open": "8.4.2",
         "prettier": "3.8.1",
         "recast": "0.23.11",
-        "remotion": "4.0.489",
+        "remotion": "4.0.490",
         "semver": "7.5.3"
       }
     },
     "node_modules/@remotion/studio-shared": {
-      "version": "4.0.489",
-      "resolved": "https://registry.npmjs.org/@remotion/studio-shared/-/studio-shared-4.0.489.tgz",
-      "integrity": "sha512-Pjfd0XrH/wtjXb4IJIJ8gLjAGbhnZPLYfwp8aWrBteghqKFyBM2BNFk1u/g5RvEN5sNL/zwE/bBBNATSuX8PHQ==",
+      "version": "4.0.490",
+      "resolved": "https://registry.npmjs.org/@remotion/studio-shared/-/studio-shared-4.0.490.tgz",
+      "integrity": "sha512-z84S704IEB8VIGnr6pZGH8XJFsrQD5fr8D5KqCXYqK6/KXW0qgv7965v3hlXhhCcD5rLfdoP8UdQHRpZolTlqw==",
       "license": "MIT",
       "dependencies": {
-        "remotion": "4.0.489"
+        "remotion": "4.0.490"
       }
     },
     "node_modules/@remotion/timeline-utils": {
-      "version": "4.0.489",
-      "resolved": "https://registry.npmjs.org/@remotion/timeline-utils/-/timeline-utils-4.0.489.tgz",
-      "integrity": "sha512-5VhndeYJY0muffx6GU6rB7eXIKntYBKsgTfuISj3/ugH+CwT6+943XYMgUPh+/LS4/DOqt+VhR6SB9FSKv8eGQ==",
+      "version": "4.0.490",
+      "resolved": "https://registry.npmjs.org/@remotion/timeline-utils/-/timeline-utils-4.0.490.tgz",
+      "integrity": "sha512-thYL+XEe6sE0xs61tpeKfCJY4jFvXhtjLa2n9pDnihSGVdvSQ5wUwbDmunQMPZvAvbiEBA8SaMrQzupF9L2BrA==",
       "license": "MIT",
       "dependencies": {
         "mediabunny": "1.50.8"
       }
     },
     "node_modules/@remotion/web-renderer": {
-      "version": "4.0.489",
-      "resolved": "https://registry.npmjs.org/@remotion/web-renderer/-/web-renderer-4.0.489.tgz",
-      "integrity": "sha512-owkisp0rbeo2tcOKKdECFnktI4rO9K7CZ/sMFWmdgYTgma5uNIS1vosMZCyE0/ZqCNA2fwNcj/zpcEpadNhfdw==",
+      "version": "4.0.490",
+      "resolved": "https://registry.npmjs.org/@remotion/web-renderer/-/web-renderer-4.0.490.tgz",
+      "integrity": "sha512-LXETwo5svXVba/MLafS8bgNxz0yrL4e85zXDFIicIsqudfOpdb9osmmqFTAima2Uw8U+k+U7k/lGeHj82qXOjg==",
       "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
         "@mediabunny/aac-encoder": "1.50.8",
         "@mediabunny/flac-encoder": "1.50.8",
         "@mediabunny/mp3-encoder": "1.50.8",
-        "@remotion/licensing": "4.0.489",
+        "@remotion/licensing": "4.0.490",
         "mediabunny": "1.50.8",
-        "remotion": "4.0.489"
+        "remotion": "4.0.490"
       },
       "peerDependencies": {
         "react": ">=18.0.0",
@@ -1496,12 +1496,12 @@
       }
     },
     "node_modules/@remotion/zod-types": {
-      "version": "4.0.489",
-      "resolved": "https://registry.npmjs.org/@remotion/zod-types/-/zod-types-4.0.489.tgz",
-      "integrity": "sha512-Il0R4O07OsaiTUDIP88owfvKyEz8wWLkSnl9UODCgTs6f9h5I/lTe+GImN2aj9cObt9S1IUFfjd0/+0AbgVjEg==",
+      "version": "4.0.490",
+      "resolved": "https://registry.npmjs.org/@remotion/zod-types/-/zod-types-4.0.490.tgz",
+      "integrity": "sha512-4xJaX+nBW14Nt9rhvTan/XTryChEfrbN1mmxVjtulrk8vxvtPmCvKRJ8kdyION2vgCNG4sza8rfFoButa9b/DQ==",
       "license": "MIT",
       "dependencies": {
-        "remotion": "4.0.489"
+        "remotion": "4.0.490"
       }
     },
     "node_modules/@rspack/binding": {
@@ -2076,9 +2076,9 @@
       "license": "MIT"
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001805",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001805.tgz",
-      "integrity": "sha512-52noaS3DubycKSXaU30TwPGIp+POyQSUVa5jBEq3vkRkY0kjyb3LQgvhU6WGyCcyXqVLWO0Cw0Q6BSdD0kUfVA==",
+      "version": "1.0.30001806",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001806.tgz",
+      "integrity": "sha512-72Cuvd95zbSYPKq6Fhg8eDJRlzgWDf7/mtoZv6Qe/DYNCEBdNxoA3+rZAU2ZhGCpZlns3EssFavaZomckT5Uuw==",
       "funding": [
         {
           "type": "opencollective",
@@ -2222,9 +2222,9 @@
       }
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.5.392",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.392.tgz",
-      "integrity": "sha512-1yQq3VQCZRwsnYc67Oc+1fge6Lwtn0hzi6zmEVkB61Zx21kTbwJAW4dFLadl5Rc1tKhG/kSpYXnfiAhu0f0a1g==",
+      "version": "1.5.393",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.393.tgz",
+      "integrity": "sha512-kiDJdIUawuEIcp9XoICKp1iTYDEbgguIPq526N1Q7jIQDeQ3CqoMx71025PI/7E48Ddtw2HuWsVjY7afEgNxmg==",
       "license": "ISC"
     },
     "node_modules/enhanced-resolve": {
@@ -2965,9 +2965,9 @@
       }
     },
     "node_modules/remotion": {
-      "version": "4.0.489",
-      "resolved": "https://registry.npmjs.org/remotion/-/remotion-4.0.489.tgz",
-      "integrity": "sha512-r7VBcWKqsGjaXT6Iv6XNFrzsZl45JvLOi6WmMYMN1zkpCoo0sm9xoi8g2pLF2Y9D7EBgygXFaG4DjjaKOVcPSg==",
+      "version": "4.0.490",
+      "resolved": "https://registry.npmjs.org/remotion/-/remotion-4.0.490.tgz",
+      "integrity": "sha512-acyJNHljJvH7+I9kXJAK5bVVN7FAyM3tILGhnwZKJoB27Xp2WQ3cMyGIh8XFwlR66/ZESWkw74s49GItHejOWQ==",
       "license": "SEE LICENSE IN LICENSE.md",
       "peerDependencies": {
         "react": ">=16.8.0",

--- a/plugins/paper-collage-video/assets/remotion-template/package.json
+++ b/plugins/paper-collage-video/assets/remotion-template/package.json
@@ -53,10 +53,10 @@
     "render:preview": "npm run project:preview -- starter-demo"
   },
   "dependencies": {
-    "@remotion/cli": "4.0.489",
+    "@remotion/cli": "4.0.490",
     "react": "19.2.7",
     "react-dom": "19.2.7",
-    "remotion": "4.0.489"
+    "remotion": "4.0.490"
   },
   "devDependencies": {
     "@types/react": "19.2.17",


### PR DESCRIPTION
## Summary

- update remotion and @remotion/cli from 4.0.489 to 4.0.490
- refresh caniuse-lite to 1.0.30001806 and electron-to-chromium to 1.5.393
- keep the root workspace and packaged plugin template lockfiles synchronized

## Why

Four separate Dependabot PRs touched the same lockfiles and were behind main. This consolidates the exact updates into one current-main change so they are tested together.

## Validation

- npm ci in root and packaged template: 0 vulnerabilities
- npm run plugin:sync
- root tests: 27/27 passed
- root TypeScript check, doctor READY, and tie-chu-mo-zhen validation passed
- packaged template tests: 21 passed, 1 skipped locally because the source template has no standalone .venv
- packaged template TypeScript check and starter-demo validation passed
- required GitHub Verify and CodeQL checks must pass before merge