### PR TITLE
fix: provision release verification dependencies

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,8 +28,20 @@ jobs:
           node-version: 20
           cache: npm
 
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.12"
+          cache: pip
+
+      - name: Install FFmpeg
+        run: sudo apt-get update && sudo apt-get install -y ffmpeg
+
       - name: Install workspace dependencies
-        run: npm ci
+        run: |
+          npm ci
+          python -m venv .venv
+          .venv/bin/python -m pip install -r requirements.txt
 
       - name: Verify release source
         run: |


### PR DESCRIPTION
## Root cause

The `v0.16.0` tag workflow ran the full test suite after only `npm ci`.
Six release-only failures were all caused by missing `ffmpeg` / `ffprobe`;
the same head had passed PR CI because `ci.yml` provisions FFmpeg and the
Python image-validation environment first.

## Fix

- set up Python 3.12 with the pip cache
- install FFmpeg
- create `.venv` and install `requirements.txt`
- keep the existing full test, type-check, bundle, and release gates unchanged

## Validation

- release workflow YAML parsed successfully
- `npm test` — 204/204 passed
- `npm run check` — passed
- `npm run bundle` — passed

After this PR is merged, the failed unpublished `v0.16.0` tag will be recreated
on the new merge commit and the release workflow will be rerun.
