### PR TITLE
chore: consolidate dependency maintenance

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
           cache: npm
 
       - name: Set up Python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@v7
         with:
           python-version: "3.12"
           cache: pip

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,7 +29,7 @@ jobs:
           cache: npm
 
       - name: Set up Python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@v7
         with:
           python-version: "3.12"
           cache: pip

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@
 
 ## [Unreleased]
 
+### Changed
+
+- 将开发版本推进到 `0.19.1-dev.1`，并同步升级 Remotion/CLI `4.0.505`、React/React DOM `19.2.8` 及对应类型包。
+- 更新 `@emnapi/runtime` 锁文件到 `1.11.3`，并将 GitHub Actions 的 Python 设置动作升级到 `actions/setup-python@v7`。
+- 重新生成 source、packaged plugin、starter proof 与 runtime fingerprint，确保依赖变化不会绕过可执行身份和发行包漂移检查。
+
 ## [0.19.0] - 2026-08-04
 
 ### Added

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,22 +1,22 @@
 {
   "name": "paper-collage-video-pipeline",
-  "version": "0.19.0",
+  "version": "0.19.1-dev.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "paper-collage-video-pipeline",
-      "version": "0.19.0",
+      "version": "0.19.1-dev.1",
       "license": "MIT",
       "dependencies": {
-        "@remotion/cli": "4.0.499",
-        "react": "19.2.7",
-        "react-dom": "19.2.7",
-        "remotion": "4.0.499"
+        "@remotion/cli": "4.0.505",
+        "react": "19.2.8",
+        "react-dom": "19.2.8",
+        "remotion": "4.0.505"
       },
       "devDependencies": {
-        "@types/react": "19.2.17",
-        "@types/react-dom": "19.2.3",
+        "@types/react": "19.2.18",
+        "@types/react-dom": "19.2.4",
         "sharp": "0.35.3",
         "typescript": "5.9.3"
       },
@@ -78,12 +78,12 @@
       }
     },
     "node_modules/@babel/core/node_modules/@babel/parser": {
-      "version": "7.29.7",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.7.tgz",
-      "integrity": "sha512-hnORnjP/1P/zFEndoeX+n+t1RwWRJiJpM/jO7FW32Kn9r5+sJB2JWOdYo4L6k78j15eCwY3Gm/7364B1EMwtNg==",
+      "version": "7.29.8",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.8.tgz",
+      "integrity": "sha512-E8lTAYNB1KW+FH+VGJuZM1ioAx2E6oVlvQFRrf5P8ZZmsiJXYAD9vTFV7yyEURNzgh1dFqMZuO6tUwcARbqFCA==",
       "license": "MIT",
       "dependencies": {
-        "@babel/types": "^7.29.7"
+        "@babel/types": "^7.29.8"
       },
       "bin": {
         "parser": "bin/babel-parser.js"
@@ -93,9 +93,9 @@
       }
     },
     "node_modules/@babel/core/node_modules/@babel/types": {
-      "version": "7.29.7",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.7.tgz",
-      "integrity": "sha512-4zBIxpPzowiZpusoFkyGVwakdRJUyuH5PxQ/PrqghfdFWWasvnCdPfQXHrenDai+gyLARulZjZowCOj6fjT4pA==",
+      "version": "7.29.8",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.8.tgz",
+      "integrity": "sha512-Vj1jF3cPfxg7OAfoI7QnVKLoILlm2JF9pnVHrX8qx7AHMiYWT+NDAA7jChlNgRS4WTLc/fD1lXLmPixluj+3Gg==",
       "license": "MIT",
       "dependencies": {
         "@babel/helper-string-parser": "^7.29.7",
@@ -115,13 +115,13 @@
       }
     },
     "node_modules/@babel/generator": {
-      "version": "7.29.7",
-      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.29.7.tgz",
-      "integrity": "sha512-DkXD5OJQaAQIdZ1bt3UZdEnHAn9Imd3IVBdX03UFe+ony9Ojw5pzr9YVKGDY1jt+Gcn/FnGkNf8r+Vj5NOJWtQ==",
+      "version": "7.29.8",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.29.8.tgz",
+      "integrity": "sha512-gZbepsdh3WDtgZKWL+vTPh71LSBrm/Y4/QDZBVCcYfmeTEEuoOYwlSy+G1StfJg+/Zy550u/3TATbm7qDbbMtg==",
       "license": "MIT",
       "dependencies": {
-        "@babel/parser": "^7.29.7",
-        "@babel/types": "^7.29.7",
+        "@babel/parser": "^7.29.8",
+        "@babel/types": "^7.29.8",
         "@jridgewell/gen-mapping": "^0.3.12",
         "@jridgewell/trace-mapping": "^0.3.28",
         "jsesc": "^3.0.2"
@@ -131,12 +131,12 @@
       }
     },
     "node_modules/@babel/generator/node_modules/@babel/parser": {
-      "version": "7.29.7",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.7.tgz",
-      "integrity": "sha512-hnORnjP/1P/zFEndoeX+n+t1RwWRJiJpM/jO7FW32Kn9r5+sJB2JWOdYo4L6k78j15eCwY3Gm/7364B1EMwtNg==",
+      "version": "7.29.8",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.8.tgz",
+      "integrity": "sha512-E8lTAYNB1KW+FH+VGJuZM1ioAx2E6oVlvQFRrf5P8ZZmsiJXYAD9vTFV7yyEURNzgh1dFqMZuO6tUwcARbqFCA==",
       "license": "MIT",
       "dependencies": {
-        "@babel/types": "^7.29.7"
+        "@babel/types": "^7.29.8"
       },
       "bin": {
         "parser": "bin/babel-parser.js"
@@ -146,9 +146,9 @@
       }
     },
     "node_modules/@babel/generator/node_modules/@babel/types": {
-      "version": "7.29.7",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.7.tgz",
-      "integrity": "sha512-4zBIxpPzowiZpusoFkyGVwakdRJUyuH5PxQ/PrqghfdFWWasvnCdPfQXHrenDai+gyLARulZjZowCOj6fjT4pA==",
+      "version": "7.29.8",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.8.tgz",
+      "integrity": "sha512-Vj1jF3cPfxg7OAfoI7QnVKLoILlm2JF9pnVHrX8qx7AHMiYWT+NDAA7jChlNgRS4WTLc/fD1lXLmPixluj+3Gg==",
       "license": "MIT",
       "dependencies": {
         "@babel/helper-string-parser": "^7.29.7",
@@ -206,9 +206,9 @@
       }
     },
     "node_modules/@babel/helper-module-imports/node_modules/@babel/types": {
-      "version": "7.29.7",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.7.tgz",
-      "integrity": "sha512-4zBIxpPzowiZpusoFkyGVwakdRJUyuH5PxQ/PrqghfdFWWasvnCdPfQXHrenDai+gyLARulZjZowCOj6fjT4pA==",
+      "version": "7.29.8",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.8.tgz",
+      "integrity": "sha512-Vj1jF3cPfxg7OAfoI7QnVKLoILlm2JF9pnVHrX8qx7AHMiYWT+NDAA7jChlNgRS4WTLc/fD1lXLmPixluj+3Gg==",
       "license": "MIT",
       "dependencies": {
         "@babel/helper-string-parser": "^7.29.7",
@@ -276,9 +276,9 @@
       }
     },
     "node_modules/@babel/helpers/node_modules/@babel/types": {
-      "version": "7.29.7",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.7.tgz",
-      "integrity": "sha512-4zBIxpPzowiZpusoFkyGVwakdRJUyuH5PxQ/PrqghfdFWWasvnCdPfQXHrenDai+gyLARulZjZowCOj6fjT4pA==",
+      "version": "7.29.8",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.8.tgz",
+      "integrity": "sha512-Vj1jF3cPfxg7OAfoI7QnVKLoILlm2JF9pnVHrX8qx7AHMiYWT+NDAA7jChlNgRS4WTLc/fD1lXLmPixluj+3Gg==",
       "license": "MIT",
       "dependencies": {
         "@babel/helper-string-parser": "^7.29.7",
@@ -315,12 +315,12 @@
       }
     },
     "node_modules/@babel/template/node_modules/@babel/parser": {
-      "version": "7.29.7",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.7.tgz",
-      "integrity": "sha512-hnORnjP/1P/zFEndoeX+n+t1RwWRJiJpM/jO7FW32Kn9r5+sJB2JWOdYo4L6k78j15eCwY3Gm/7364B1EMwtNg==",
+      "version": "7.29.8",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.8.tgz",
+      "integrity": "sha512-E8lTAYNB1KW+FH+VGJuZM1ioAx2E6oVlvQFRrf5P8ZZmsiJXYAD9vTFV7yyEURNzgh1dFqMZuO6tUwcARbqFCA==",
       "license": "MIT",
       "dependencies": {
-        "@babel/types": "^7.29.7"
+        "@babel/types": "^7.29.8"
       },
       "bin": {
         "parser": "bin/babel-parser.js"
@@ -330,9 +330,9 @@
       }
     },
     "node_modules/@babel/template/node_modules/@babel/types": {
-      "version": "7.29.7",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.7.tgz",
-      "integrity": "sha512-4zBIxpPzowiZpusoFkyGVwakdRJUyuH5PxQ/PrqghfdFWWasvnCdPfQXHrenDai+gyLARulZjZowCOj6fjT4pA==",
+      "version": "7.29.8",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.8.tgz",
+      "integrity": "sha512-Vj1jF3cPfxg7OAfoI7QnVKLoILlm2JF9pnVHrX8qx7AHMiYWT+NDAA7jChlNgRS4WTLc/fD1lXLmPixluj+3Gg==",
       "license": "MIT",
       "dependencies": {
         "@babel/helper-string-parser": "^7.29.7",
@@ -343,17 +343,17 @@
       }
     },
     "node_modules/@babel/traverse": {
-      "version": "7.29.7",
-      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.29.7.tgz",
-      "integrity": "sha512-EhlfNQtZ+NK22w5BM61ciuiq1m58ed33Wr1Xan//ZRTy6hgjnwyCffRYwzsGXdASJSUJ1guZILsErh1eQcl+zw==",
+      "version": "7.29.8",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.29.8.tgz",
+      "integrity": "sha512-I5z7H3bf/41ktsNVLtpN0wAa336HkqIHQ5BuPLEhTkt1jVSyZpeNKIzTgEWmlxjdg81R0IgUCcaE+Ok3NvrfZg==",
       "license": "MIT",
       "dependencies": {
         "@babel/code-frame": "^7.29.7",
-        "@babel/generator": "^7.29.7",
+        "@babel/generator": "^7.29.8",
         "@babel/helper-globals": "^7.29.7",
-        "@babel/parser": "^7.29.7",
+        "@babel/parser": "^7.29.8",
         "@babel/template": "^7.29.7",
-        "@babel/types": "^7.29.7",
+        "@babel/types": "^7.29.8",
         "debug": "^4.3.1"
       },
       "engines": {
@@ -361,12 +361,12 @@
       }
     },
     "node_modules/@babel/traverse/node_modules/@babel/parser": {
-      "version": "7.29.7",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.7.tgz",
-      "integrity": "sha512-hnORnjP/1P/zFEndoeX+n+t1RwWRJiJpM/jO7FW32Kn9r5+sJB2JWOdYo4L6k78j15eCwY3Gm/7364B1EMwtNg==",
+      "version": "7.29.8",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.8.tgz",
+      "integrity": "sha512-E8lTAYNB1KW+FH+VGJuZM1ioAx2E6oVlvQFRrf5P8ZZmsiJXYAD9vTFV7yyEURNzgh1dFqMZuO6tUwcARbqFCA==",
       "license": "MIT",
       "dependencies": {
-        "@babel/types": "^7.29.7"
+        "@babel/types": "^7.29.8"
       },
       "bin": {
         "parser": "bin/babel-parser.js"
@@ -376,9 +376,9 @@
       }
     },
     "node_modules/@babel/traverse/node_modules/@babel/types": {
-      "version": "7.29.7",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.7.tgz",
-      "integrity": "sha512-4zBIxpPzowiZpusoFkyGVwakdRJUyuH5PxQ/PrqghfdFWWasvnCdPfQXHrenDai+gyLARulZjZowCOj6fjT4pA==",
+      "version": "7.29.8",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.8.tgz",
+      "integrity": "sha512-Vj1jF3cPfxg7OAfoI7QnVKLoILlm2JF9pnVHrX8qx7AHMiYWT+NDAA7jChlNgRS4WTLc/fD1lXLmPixluj+3Gg==",
       "license": "MIT",
       "dependencies": {
         "@babel/helper-string-parser": "^7.29.7",
@@ -414,9 +414,9 @@
       }
     },
     "node_modules/@emnapi/runtime": {
-      "version": "1.11.2",
-      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.11.2.tgz",
-      "integrity": "sha512-kyOl3X0DuTiT1h2ft8r2fYO8JYtU9a9Xis/zBSiGArNaagCOWx90N1k2wxp18czFDH+OgcWGb5ZP/XMt3dcyPA==",
+      "version": "1.11.3",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.11.3.tgz",
+      "integrity": "sha512-Xz4Tpyki7XyrpbUK1jR1AhdAdaXyhhY4lZ3neLodmhpuWfy2PAQN5B46sAiU4liOXGLkHypn/qU+jvfWSCYYLA==",
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -1536,21 +1536,21 @@
       }
     },
     "node_modules/@remotion/bundler": {
-      "version": "4.0.499",
-      "resolved": "https://registry.npmjs.org/@remotion/bundler/-/bundler-4.0.499.tgz",
-      "integrity": "sha512-88C7WxlC9DSxEOSnJL/HV7Xl16OIKnEzl90BvIM083pNBA/laAEJvryaXmSQ3FuI5CSGuVA336YgboOWagqmAg==",
+      "version": "4.0.505",
+      "resolved": "https://registry.npmjs.org/@remotion/bundler/-/bundler-4.0.505.tgz",
+      "integrity": "sha512-yAq9iliYeHB3qp3Jl1w829lwHwlY6C2UF8d1hPHaMjFWiHRHikR5al9BHtVSrYC4yIQmNXJTGPNjgC9GCteFtQ==",
       "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
-        "@remotion/media-parser": "4.0.499",
-        "@remotion/studio": "4.0.499",
-        "@remotion/studio-shared": "4.0.499",
-        "@remotion/timeline-utils": "4.0.499",
+        "@remotion/media-parser": "4.0.505",
+        "@remotion/studio": "4.0.505",
+        "@remotion/studio-shared": "4.0.505",
+        "@remotion/timeline-utils": "4.0.505",
         "@rspack/core": "1.7.11",
         "@rspack/plugin-react-refresh": "1.6.1",
         "css-loader": "7.1.4",
         "esbuild": "0.28.1",
         "react-refresh": "0.18.0",
-        "remotion": "4.0.499",
+        "remotion": "4.0.505",
         "style-loader": "4.0.0",
         "webpack": "5.105.0"
       },
@@ -1559,37 +1559,30 @@
         "react-dom": ">=16.8.0"
       }
     },
-    "node_modules/@remotion/canvas-capture": {
-      "version": "4.0.499",
-      "resolved": "https://registry.npmjs.org/@remotion/canvas-capture/-/canvas-capture-4.0.499.tgz",
-      "integrity": "sha512-S2Q5eqNnjkRmxm5FZMadI21bPuLyKa2+zRLh3c2EDjRS1C400rx19UCmG1Ne9W38ybInm/MohcLS3EkaNHZqrw==",
-      "license": "Remotion License",
-      "dependencies": {
-        "mediabunny": "1.50.8",
-        "remotion": "4.0.499"
-      },
-      "peerDependencies": {
-        "react": ">=16.8.0",
-        "react-dom": ">=16.8.0"
-      }
+    "node_modules/@remotion/captions": {
+      "version": "4.0.505",
+      "resolved": "https://registry.npmjs.org/@remotion/captions/-/captions-4.0.505.tgz",
+      "integrity": "sha512-wS5jM6/rKj6JPT9h0lDl0nbaOOs1hje/jHjvIturjX5IuEPlx6HVcDzcT/+hP6AXkYddGd/DUmZ3T/8S/zjMRg==",
+      "license": "MIT"
     },
     "node_modules/@remotion/cli": {
-      "version": "4.0.499",
-      "resolved": "https://registry.npmjs.org/@remotion/cli/-/cli-4.0.499.tgz",
-      "integrity": "sha512-IOscAgjRECQhwUaXEFBc3x6FvRaEcQNyx3qGxyprPL+K3xwmfTVJgYI8igMQZUgEUxtwdDQ2hjMUB+30wgxa1g==",
+      "version": "4.0.505",
+      "resolved": "https://registry.npmjs.org/@remotion/cli/-/cli-4.0.505.tgz",
+      "integrity": "sha512-6YBzX/H060PPC2MqLLEWSfj0pSeEDY4coVSH7BAtrRANJNjVArfMWS3cmGcKhXLIV+wvwcTm6HhPRcJAeq7LBw==",
       "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
-        "@remotion/bundler": "4.0.499",
-        "@remotion/media-utils": "4.0.499",
-        "@remotion/player": "4.0.499",
-        "@remotion/renderer": "4.0.499",
-        "@remotion/studio": "4.0.499",
-        "@remotion/studio-server": "4.0.499",
-        "@remotion/studio-shared": "4.0.499",
+        "@remotion/bundler": "4.0.505",
+        "@remotion/media-utils": "4.0.505",
+        "@remotion/player": "4.0.505",
+        "@remotion/renderer": "4.0.505",
+        "@remotion/studio": "4.0.505",
+        "@remotion/studio-server": "4.0.505",
+        "@remotion/studio-shared": "4.0.505",
         "dotenv": "17.3.1",
         "minimist": "1.2.6",
         "prompts": "2.4.2",
-        "remotion": "4.0.499"
+        "remotion": "4.0.505",
+        "semver": "7.5.3"
       },
       "bin": {
         "remotion": "remotion-cli.js",
@@ -1602,9 +1595,9 @@
       }
     },
     "node_modules/@remotion/compositor-darwin-arm64": {
-      "version": "4.0.499",
-      "resolved": "https://registry.npmjs.org/@remotion/compositor-darwin-arm64/-/compositor-darwin-arm64-4.0.499.tgz",
-      "integrity": "sha512-7pBC1NwnzFFHRmCIx0DlRMb53SIwGb24Abx28f3wSdrgYVAU9A0Ema/Y+h0dZVGIwC3RO0iUQgs3h8ra7XVB6Q==",
+      "version": "4.0.505",
+      "resolved": "https://registry.npmjs.org/@remotion/compositor-darwin-arm64/-/compositor-darwin-arm64-4.0.505.tgz",
+      "integrity": "sha512-ULBrt1pbv8oRhpozIxHhlShWqf8SYxuAg7mjRAfp0k3dJT5OCljhg//Zbl60Wsz9nQQvB+0/pAhyXvsEIWAm6Q==",
       "cpu": [
         "arm64"
       ],
@@ -1614,9 +1607,9 @@
       ]
     },
     "node_modules/@remotion/compositor-darwin-x64": {
-      "version": "4.0.499",
-      "resolved": "https://registry.npmjs.org/@remotion/compositor-darwin-x64/-/compositor-darwin-x64-4.0.499.tgz",
-      "integrity": "sha512-gFGYRH7CRIqhOuxQDGnIoHCEMhUeu7zJWuA/fy0hPPnWayDMsWChfY9+yGHsWGBePbNdXEM2HBcuC4RxDLORtQ==",
+      "version": "4.0.505",
+      "resolved": "https://registry.npmjs.org/@remotion/compositor-darwin-x64/-/compositor-darwin-x64-4.0.505.tgz",
+      "integrity": "sha512-nRllcfW9ifW7yvgQj3hXY8pjGhisWc0p3NokLgvRAu3CcJc1KXHJVu9BP1TgTnjx69KaRii/GtltQVXC+J/xhg==",
       "cpu": [
         "x64"
       ],
@@ -1626,9 +1619,9 @@
       ]
     },
     "node_modules/@remotion/compositor-linux-arm64-gnu": {
-      "version": "4.0.499",
-      "resolved": "https://registry.npmjs.org/@remotion/compositor-linux-arm64-gnu/-/compositor-linux-arm64-gnu-4.0.499.tgz",
-      "integrity": "sha512-aLSwT8857xWuPaYFDSOVPSVp6efXnPYS8MEUdKQdCoqXNpgufugCAGL/xzagPo2A3wD+Ocuzj6+bcsBna3ivMg==",
+      "version": "4.0.505",
+      "resolved": "https://registry.npmjs.org/@remotion/compositor-linux-arm64-gnu/-/compositor-linux-arm64-gnu-4.0.505.tgz",
+      "integrity": "sha512-++UMpFFRAqNr3iGgtnOqOgSpH8Hf8zCpG1K8LFKp/o2MEq7q3s239TXFHNrgUFMUJ/HXio5PS9X238Nx24mD0Q==",
       "cpu": [
         "arm64"
       ],
@@ -1638,9 +1631,9 @@
       ]
     },
     "node_modules/@remotion/compositor-linux-arm64-musl": {
-      "version": "4.0.499",
-      "resolved": "https://registry.npmjs.org/@remotion/compositor-linux-arm64-musl/-/compositor-linux-arm64-musl-4.0.499.tgz",
-      "integrity": "sha512-bC3/NocB8FUiieUBZtE2A19sr34cLDHo5r0Q1aUevsI/RpJkq9LYJzmifMgO+8OxVxv4nxg8cSryHrDpEsylZQ==",
+      "version": "4.0.505",
+      "resolved": "https://registry.npmjs.org/@remotion/compositor-linux-arm64-musl/-/compositor-linux-arm64-musl-4.0.505.tgz",
+      "integrity": "sha512-ouIlMngzE2lLyaBEBFS8curBeigqBnz2PvXKIbluAwWSRuDgBM10i6Ya4D5Q3VWJNaqNgaDfxET4b+/RPFd7Hw==",
       "cpu": [
         "arm64"
       ],
@@ -1650,9 +1643,9 @@
       ]
     },
     "node_modules/@remotion/compositor-linux-x64-gnu": {
-      "version": "4.0.499",
-      "resolved": "https://registry.npmjs.org/@remotion/compositor-linux-x64-gnu/-/compositor-linux-x64-gnu-4.0.499.tgz",
-      "integrity": "sha512-I9aOX1tpdSwi+jwYcZjg0V8jnp0eVKBWe6iaD3V85USrxxFu4LdvHwJ+Lh6kWC7L1mlrlrac9AGkZm70AoBvWQ==",
+      "version": "4.0.505",
+      "resolved": "https://registry.npmjs.org/@remotion/compositor-linux-x64-gnu/-/compositor-linux-x64-gnu-4.0.505.tgz",
+      "integrity": "sha512-Byyq9lnlxtfTvNmYKoB83GJjS4u26vrOYczgxb1DusISWBijMcG9oVjmYCNI5wdqEuhnEPAAAK7zoGzxA9B6pQ==",
       "cpu": [
         "x64"
       ],
@@ -1662,9 +1655,9 @@
       ]
     },
     "node_modules/@remotion/compositor-linux-x64-musl": {
-      "version": "4.0.499",
-      "resolved": "https://registry.npmjs.org/@remotion/compositor-linux-x64-musl/-/compositor-linux-x64-musl-4.0.499.tgz",
-      "integrity": "sha512-pDBDfyuaVBueuIqd88SSdCerSzixm3toZZfLbS4ACxLUqtGJshRcmuFeWiaUALSbtwa4KIPMPzgPGCu5cmnuRA==",
+      "version": "4.0.505",
+      "resolved": "https://registry.npmjs.org/@remotion/compositor-linux-x64-musl/-/compositor-linux-x64-musl-4.0.505.tgz",
+      "integrity": "sha512-9wV5K/bN0MbW4ZOYj5yVjo4SIBQf2QzP+IBin9Rt7/uoBh9i2qSENiaXY9lX52rPn9nuYjx3ww7Btxx1br4hqg==",
       "cpu": [
         "x64"
       ],
@@ -1674,9 +1667,9 @@
       ]
     },
     "node_modules/@remotion/compositor-win32-x64-msvc": {
-      "version": "4.0.499",
-      "resolved": "https://registry.npmjs.org/@remotion/compositor-win32-x64-msvc/-/compositor-win32-x64-msvc-4.0.499.tgz",
-      "integrity": "sha512-sOYpHz3LmW7u0JR3qg3FA2fTP07pEzY6lhKutwTUDAoQ7MJaHdRYBU7DGf/dpBbaGugQ36hi9GKh0jJLbt1aWw==",
+      "version": "4.0.505",
+      "resolved": "https://registry.npmjs.org/@remotion/compositor-win32-x64-msvc/-/compositor-win32-x64-msvc-4.0.505.tgz",
+      "integrity": "sha512-9NSzLa9aMnAN/M3P0EUT1mnhC1EtVR2UUACwOf8eehZgFnxc0nCdhwx4TMS9UubpY7vH81bTl7xq60/BPvBDBQ==",
       "cpu": [
         "x64"
       ],
@@ -1685,32 +1678,26 @@
         "win32"
       ]
     },
-    "node_modules/@remotion/drag-and-drop": {
-      "version": "4.0.499",
-      "resolved": "https://registry.npmjs.org/@remotion/drag-and-drop/-/drag-and-drop-4.0.499.tgz",
-      "integrity": "sha512-0BBcRlRvkfbTo/ZhLLCOlaXvtFGO4Am6M8YGemEjh/HS7wkIkftpWlLDEEJwNeAlWEa11/EYpgWxFGF3huYOBQ==",
-      "license": "Remotion License"
-    },
     "node_modules/@remotion/licensing": {
-      "version": "4.0.499",
-      "resolved": "https://registry.npmjs.org/@remotion/licensing/-/licensing-4.0.499.tgz",
-      "integrity": "sha512-dKjaYAJsxCUXDvAjJW8bHIUe+dYAXEcq2M0RVrqdS1CEUZPUQXhzIbYILX+slcVb5c8/DD5t+edm7d2VSY81Tg==",
+      "version": "4.0.505",
+      "resolved": "https://registry.npmjs.org/@remotion/licensing/-/licensing-4.0.505.tgz",
+      "integrity": "sha512-kHP8puHqEqaiHk+qQDaM7xEPrd/bYbPO/ao9ToePudHiOkueRzCOd24u9ujoMkVJy1FHxFMB/VaYZztwhXFYUw==",
       "license": "MIT"
     },
     "node_modules/@remotion/media-parser": {
-      "version": "4.0.499",
-      "resolved": "https://registry.npmjs.org/@remotion/media-parser/-/media-parser-4.0.499.tgz",
-      "integrity": "sha512-3RX9OFko0gW1ixi87eoYx2FLOndVb4eo/KONIiq0yKwho1IMYAq8r8tIkqmSksVG0RlWqW4FwXa9kp9lhiqfDA==",
+      "version": "4.0.505",
+      "resolved": "https://registry.npmjs.org/@remotion/media-parser/-/media-parser-4.0.505.tgz",
+      "integrity": "sha512-m95m0lc7UODwri8zdDFJcrKZM6CYSvT2fDD1rs0GrvvEf5HK+Puk1X1JZe0jnJATwtnMAguMP+HniS7KRbVTdA==",
       "license": "Remotion License https://remotion.dev/license"
     },
     "node_modules/@remotion/media-utils": {
-      "version": "4.0.499",
-      "resolved": "https://registry.npmjs.org/@remotion/media-utils/-/media-utils-4.0.499.tgz",
-      "integrity": "sha512-XqCX58ZwI80YM9CqzasKYeCVGRaINMhRvaCQ4H953PD+pRkTxk3bFcx97x4oj0Y0KjGDWnBvzsa5Tt0Jx7JUBA==",
+      "version": "4.0.505",
+      "resolved": "https://registry.npmjs.org/@remotion/media-utils/-/media-utils-4.0.505.tgz",
+      "integrity": "sha512-Y5EGhjh7uw3ERR6IUdmEPVyXy5gKDXYNIDM5B1R6WDxeAmybKOGE2aaYB01JrXZbVF+BDizaEZphkiegDlnSHw==",
       "license": "MIT",
       "dependencies": {
         "mediabunny": "1.50.8",
-        "remotion": "4.0.499"
+        "remotion": "4.0.505"
       },
       "peerDependencies": {
         "react": ">=16.8.0",
@@ -1718,12 +1705,12 @@
       }
     },
     "node_modules/@remotion/player": {
-      "version": "4.0.499",
-      "resolved": "https://registry.npmjs.org/@remotion/player/-/player-4.0.499.tgz",
-      "integrity": "sha512-3qEjNUj0KamSgWLXDhXnHdVMIx0EBsdr7XM5+QGldj1EiZH54vXVKJsWJj6SYfPbaskfEWI0wjKGGh0ml3vJrw==",
+      "version": "4.0.505",
+      "resolved": "https://registry.npmjs.org/@remotion/player/-/player-4.0.505.tgz",
+      "integrity": "sha512-xBoYlUsoJLna/h7YcHZcdfjDYQKyRkvf2O5tyk1/q79x8oDF4PSIbLMXHHdwXpb3pWPmOMic0EtYPfugvxdxfQ==",
       "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
-        "remotion": "4.0.499"
+        "remotion": "4.0.505"
       },
       "peerDependencies": {
         "react": ">=16.8.0",
@@ -1731,26 +1718,26 @@
       }
     },
     "node_modules/@remotion/renderer": {
-      "version": "4.0.499",
-      "resolved": "https://registry.npmjs.org/@remotion/renderer/-/renderer-4.0.499.tgz",
-      "integrity": "sha512-KqzYTBIYVWuqKd5tfYaBq9CWKRYZJq6/PL5++/20dQaTSHQQEMTpyyGrOs0RsyCiy8Ofr8eYB765mIeIxulS4Q==",
+      "version": "4.0.505",
+      "resolved": "https://registry.npmjs.org/@remotion/renderer/-/renderer-4.0.505.tgz",
+      "integrity": "sha512-TKhw0v7qeCJenSWBaLS65Irocw+aCDFIs6zp+2ocA6zHk/nAJkdIuhPQU6mWWPs/YGp6U1sPGe1+T3nSeYcEOg==",
       "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
-        "@remotion/licensing": "4.0.499",
-        "@remotion/streaming": "4.0.499",
+        "@remotion/licensing": "4.0.505",
+        "@remotion/streaming": "4.0.505",
         "execa": "5.1.1",
-        "remotion": "4.0.499",
-        "source-map": "0.8.0-beta.0",
+        "remotion": "4.0.505",
+        "source-map": "0.8.0",
         "ws": "8.21.0"
       },
       "optionalDependencies": {
-        "@remotion/compositor-darwin-arm64": "4.0.499",
-        "@remotion/compositor-darwin-x64": "4.0.499",
-        "@remotion/compositor-linux-arm64-gnu": "4.0.499",
-        "@remotion/compositor-linux-arm64-musl": "4.0.499",
-        "@remotion/compositor-linux-x64-gnu": "4.0.499",
-        "@remotion/compositor-linux-x64-musl": "4.0.499",
-        "@remotion/compositor-win32-x64-msvc": "4.0.499"
+        "@remotion/compositor-darwin-arm64": "4.0.505",
+        "@remotion/compositor-darwin-x64": "4.0.505",
+        "@remotion/compositor-linux-arm64-gnu": "4.0.505",
+        "@remotion/compositor-linux-arm64-musl": "4.0.505",
+        "@remotion/compositor-linux-x64-gnu": "4.0.505",
+        "@remotion/compositor-linux-x64-musl": "4.0.505",
+        "@remotion/compositor-win32-x64-msvc": "4.0.505"
       },
       "peerDependencies": {
         "react": ">=16.8.0",
@@ -1758,31 +1745,31 @@
       }
     },
     "node_modules/@remotion/streaming": {
-      "version": "4.0.499",
-      "resolved": "https://registry.npmjs.org/@remotion/streaming/-/streaming-4.0.499.tgz",
-      "integrity": "sha512-PYIZc7KNJyG+qvKYzftrPbfVJw5B31F+6Uage0Qf54c+cpa69Us/kFK8quNbd/zZcwxvGvCR+fCkn41TJ53FfQ==",
+      "version": "4.0.505",
+      "resolved": "https://registry.npmjs.org/@remotion/streaming/-/streaming-4.0.505.tgz",
+      "integrity": "sha512-b3tTq2Dzqe5FlWEW8z69PGqIEgf6atG/374TOReOFEW9c4KQYaYO7Gl+iHMP/ZdE80DiiTaVqneRLpdELX4dMA==",
       "license": "MIT"
     },
     "node_modules/@remotion/studio": {
-      "version": "4.0.499",
-      "resolved": "https://registry.npmjs.org/@remotion/studio/-/studio-4.0.499.tgz",
-      "integrity": "sha512-oW5hvpwZmstFY9zQZuqAjoAUfujoZna2T9Eq636RwhzDqTaCa3zvV8ojrPfAgFOl8XEFwHLK+UPxAijzOXVYMg==",
+      "version": "4.0.505",
+      "resolved": "https://registry.npmjs.org/@remotion/studio/-/studio-4.0.505.tgz",
+      "integrity": "sha512-kMjhB79v5fWYI+3rUtQTzrRn2Lw3a1kK/qMbYYYvNSfbWpAof7AuPCVj1YA93xt8Q0Nna3ISOw7wx2SXdTDzkQ==",
       "license": "MIT",
       "dependencies": {
         "@jridgewell/trace-mapping": "0.3.31",
-        "@remotion/canvas-capture": "4.0.499",
-        "@remotion/drag-and-drop": "4.0.499",
-        "@remotion/media-utils": "4.0.499",
-        "@remotion/player": "4.0.499",
-        "@remotion/renderer": "4.0.499",
-        "@remotion/studio-shared": "4.0.499",
-        "@remotion/timeline-utils": "4.0.499",
-        "@remotion/web-renderer": "4.0.499",
-        "@remotion/zod-types": "4.0.499",
+        "@remotion/captions": "4.0.505",
+        "@remotion/media-utils": "4.0.505",
+        "@remotion/player": "4.0.505",
+        "@remotion/renderer": "4.0.505",
+        "@remotion/studio-protocol": "4.0.505",
+        "@remotion/studio-shared": "4.0.505",
+        "@remotion/timeline-utils": "4.0.505",
+        "@remotion/web-renderer": "4.0.505",
+        "@remotion/zod-types": "4.0.505",
         "mediabunny": "1.50.8",
         "memfs": "3.4.3",
         "open": "8.4.2",
-        "remotion": "4.0.499",
+        "remotion": "4.0.505",
         "semver": "7.5.3",
         "zod": "4.4.3"
       },
@@ -1791,18 +1778,39 @@
         "react-dom": ">=16.8.0"
       }
     },
-    "node_modules/@remotion/studio-server": {
-      "version": "4.0.499",
-      "resolved": "https://registry.npmjs.org/@remotion/studio-server/-/studio-server-4.0.499.tgz",
-      "integrity": "sha512-80VI/QY5ysarjbK6gPn6xysIEhha2r1WIbK2mN4TzVSmQXVTB14YPw1noHwCGuNWETj+V8L34AHpAtZp2yxl9Q==",
+    "node_modules/@remotion/studio-codemods": {
+      "version": "4.0.505",
+      "resolved": "https://registry.npmjs.org/@remotion/studio-codemods/-/studio-codemods-4.0.505.tgz",
+      "integrity": "sha512-TYQ2daceyTMEkd4o0PQ/br0okvNaZBVPwz2zZ6xHic0XCY3YVgtAfs5D4sbBW73A+KtJjk7SxfVtPaTxslhcTA==",
       "license": "MIT",
       "dependencies": {
         "@babel/parser": "7.24.1",
         "@babel/types": "7.24.0",
-        "@remotion/bundler": "4.0.499",
-        "@remotion/drag-and-drop": "4.0.499",
-        "@remotion/renderer": "4.0.499",
-        "@remotion/studio-shared": "4.0.499",
+        "@remotion/studio-shared": "4.0.505",
+        "ast-types": "0.16.1",
+        "recast": "0.23.11",
+        "remotion": "4.0.505"
+      }
+    },
+    "node_modules/@remotion/studio-protocol": {
+      "version": "4.0.505",
+      "resolved": "https://registry.npmjs.org/@remotion/studio-protocol/-/studio-protocol-4.0.505.tgz",
+      "integrity": "sha512-1/6/uX14N8uwgywSYQT9Z3RuTyGTL3n9VsBKmAm3tkoX5jXgCnVHrTgmW7XqW1YyMtTBsFres1I6+6rxWC2xsg==",
+      "license": "Remotion License"
+    },
+    "node_modules/@remotion/studio-server": {
+      "version": "4.0.505",
+      "resolved": "https://registry.npmjs.org/@remotion/studio-server/-/studio-server-4.0.505.tgz",
+      "integrity": "sha512-tLIFWWQFwc05UmdEB1HlqTkaObkHvDhTdD11MZdZZLuCwBR7uXlFxahaslmpTBYzDKT0osct5gluRlywbWht3Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "7.24.1",
+        "@babel/types": "7.24.0",
+        "@remotion/bundler": "4.0.505",
+        "@remotion/renderer": "4.0.505",
+        "@remotion/studio-codemods": "4.0.505",
+        "@remotion/studio-protocol": "4.0.505",
+        "@remotion/studio-shared": "4.0.505",
         "@svgr/core": "8.1.0",
         "@svgr/plugin-jsx": "8.1.0",
         "kiwi-schema": "0.5.0",
@@ -1810,41 +1818,42 @@
         "open": "8.4.2",
         "prettier": "3.8.1",
         "recast": "0.23.11",
-        "remotion": "4.0.499",
-        "semver": "7.5.3"
+        "remotion": "4.0.505",
+        "semver": "7.5.3",
+        "zod": "4.4.3"
       }
     },
     "node_modules/@remotion/studio-shared": {
-      "version": "4.0.499",
-      "resolved": "https://registry.npmjs.org/@remotion/studio-shared/-/studio-shared-4.0.499.tgz",
-      "integrity": "sha512-wGMhqAk8t4UtFneYY8mkUQEWFM95ACQ0Tf87Oh1rPV3RVSN49irQLcBK1eQ8kDM9I9G3oFGQdMYS/6BA8dHnWw==",
+      "version": "4.0.505",
+      "resolved": "https://registry.npmjs.org/@remotion/studio-shared/-/studio-shared-4.0.505.tgz",
+      "integrity": "sha512-0Q8p76ZqTo9q990lGpvBNMeH2a45aqmFBBt8ld2e+KGlSYQPXWAcXaLO73UAycpLr6vge9FRXXYJgmPAynmMyw==",
       "license": "MIT",
       "dependencies": {
-        "@remotion/drag-and-drop": "4.0.499",
-        "remotion": "4.0.499"
+        "@remotion/studio-protocol": "4.0.505",
+        "remotion": "4.0.505"
       }
     },
     "node_modules/@remotion/timeline-utils": {
-      "version": "4.0.499",
-      "resolved": "https://registry.npmjs.org/@remotion/timeline-utils/-/timeline-utils-4.0.499.tgz",
-      "integrity": "sha512-1ml1W9ia/Aaqauqjj7XRMbY3IMIybzZKZJ7C5tm+Dm8lq2QmCH5QQHi84ToLLVOF8T6m/n+wIZXyhUsNQLh94g==",
+      "version": "4.0.505",
+      "resolved": "https://registry.npmjs.org/@remotion/timeline-utils/-/timeline-utils-4.0.505.tgz",
+      "integrity": "sha512-BO81ejrabU5tNmQxd0+hPSZP6JumxVZ8cqGy/iR/AQ9lqfMUtWdrJg9IsOUCT0sEkQyiKwVzeDVji88xBMngOQ==",
       "license": "MIT",
       "dependencies": {
         "mediabunny": "1.50.8"
       }
     },
     "node_modules/@remotion/web-renderer": {
-      "version": "4.0.499",
-      "resolved": "https://registry.npmjs.org/@remotion/web-renderer/-/web-renderer-4.0.499.tgz",
-      "integrity": "sha512-wjxJ1wLrzLxO0nTu/1IdRVd3J1kipzatkfkaXwre8gdEwVTg10XD33niufGuD35ykCH4LGOCmkMlhRcXopJ1lA==",
+      "version": "4.0.505",
+      "resolved": "https://registry.npmjs.org/@remotion/web-renderer/-/web-renderer-4.0.505.tgz",
+      "integrity": "sha512-f2i985v434oi1oxoudDiSj0KFdqiY+8GbhQMHhqI5ag2zsWzBouE2X0WiSnrDd2rLuIlQqE8dIo19Txd24lv1g==",
       "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
         "@mediabunny/aac-encoder": "1.50.8",
         "@mediabunny/flac-encoder": "1.50.8",
         "@mediabunny/mp3-encoder": "1.50.8",
-        "@remotion/licensing": "4.0.499",
+        "@remotion/licensing": "4.0.505",
         "mediabunny": "1.50.8",
-        "remotion": "4.0.499"
+        "remotion": "4.0.505"
       },
       "peerDependencies": {
         "react": ">=18.0.0",
@@ -1852,12 +1861,12 @@
       }
     },
     "node_modules/@remotion/zod-types": {
-      "version": "4.0.499",
-      "resolved": "https://registry.npmjs.org/@remotion/zod-types/-/zod-types-4.0.499.tgz",
-      "integrity": "sha512-UyKMhwnS9T6NgHUznscZ4+pPkvjEIqfd6gEVqW6JkM3C7OcZfOBRcF7FWZZq96eyTIxJHLxCUDdlAZr8JcRlTA==",
+      "version": "4.0.505",
+      "resolved": "https://registry.npmjs.org/@remotion/zod-types/-/zod-types-4.0.505.tgz",
+      "integrity": "sha512-QvsbVae3fQb7ZoYfaAS81huYX/19/4hDIIwzYGlIDCz+SI5UukFd4GNvqcrFu+Uo5kFP+8S98XGlp7KBL+FpHw==",
       "license": "MIT",
       "dependencies": {
-        "remotion": "4.0.499"
+        "remotion": "4.0.505"
       }
     },
     "node_modules/@rspack/binding": {
@@ -2326,18 +2335,18 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "26.1.1",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-26.1.1.tgz",
-      "integrity": "sha512-nxAkRSVkN1Y0JC1W8ky/fTfkGsMmcrRsbx+3XoZE+rMOX71kLYTV7fLXpqud1GpbpP5TuffXFqfX7fH2GgZREw==",
+      "version": "26.1.2",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-26.1.2.tgz",
+      "integrity": "sha512-Vu4a5UFA9rIIFJ7rB/Vaafh9lrCQszopTCx6KjFboXTGQbPNasehVR5TEiithSDGyd1DEiUByggTZsg8jukeIg==",
       "license": "MIT",
       "dependencies": {
         "undici-types": "~8.3.0"
       }
     },
     "node_modules/@types/react": {
-      "version": "19.2.17",
-      "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.17.tgz",
-      "integrity": "sha512-MXfmqaVPEVgkBT/aY0aGCkRWWtByiYQXo3xdQ8r5RzuFrPiRn8Gar2tQdXSUQ2GKV3bkXckek89V8wQBY2Q/Aw==",
+      "version": "19.2.18",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.18.tgz",
+      "integrity": "sha512-AnzbBERsrLKtk2XSfTbYRLjQPdy116Sty4q+T+Bp3IC4l6jNBvreVPAHmpq9qhXQM7CXZPjLVmGMw9sy+hxQ3w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2345,9 +2354,9 @@
       }
     },
     "node_modules/@types/react-dom": {
-      "version": "19.2.3",
-      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-19.2.3.tgz",
-      "integrity": "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==",
+      "version": "19.2.4",
+      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-19.2.4.tgz",
+      "integrity": "sha512-Bsc+QHgp+P/F02XDzNCY9jnZNCUuLki36KT7VKrTXXLdHf+vHMNZnW1rVu5DNW/rCK+fya3DATySbLM4yhtKUw==",
       "dev": true,
       "license": "MIT",
       "peerDependencies": {
@@ -2513,9 +2522,9 @@
       "license": "Apache-2.0"
     },
     "node_modules/acorn": {
-      "version": "8.17.0",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.17.0.tgz",
-      "integrity": "sha512-xRQbDb9BnwDafYNn6Vwl839DYVjqXYb1XVGtWAZ1kcDc6iwAL4hg3B1dZlRiuENFeO2H53gFG3in621AdERVAg==",
+      "version": "8.18.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.18.0.tgz",
+      "integrity": "sha512-lGq+9yr1/GuAWaVYIHRjvvySG5/4VfKIvC8EWxStPdcDh/Ka7FG3twP6v4d5BkravUilhIAsG4Qj83t02LWUPQ==",
       "license": "MIT",
       "bin": {
         "acorn": "bin/acorn"
@@ -2600,9 +2609,9 @@
       }
     },
     "node_modules/baseline-browser-mapping": {
-      "version": "2.11.4",
-      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.11.4.tgz",
-      "integrity": "sha512-s4+sLr9mZ/CyqeRritFeYV/Zx73OAtmaHn6kkBS1XRoJn1hrg3xIDUcpicAEX68tkcIN0iBCgti31C8zxtkhsQ==",
+      "version": "2.11.12",
+      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.11.12.tgz",
+      "integrity": "sha512-r7WnVImvVCeFpf2DOXfy41aPWzeNg3H/A2X4dKmy1QL0MSyyk/e7z8ihJ3N6Nn2PsdhkVlqnEfnUE4a05P2aTA==",
       "license": "Apache-2.0",
       "bin": {
         "baseline-browser-mapping": "dist/cli.cjs"
@@ -2877,15 +2886,15 @@
       }
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.5.396",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.396.tgz",
-      "integrity": "sha512-yHiw2Y3C3H9U6TMbOfoWK/BPreiOPXRfTWPBwQBoZG6/8TB6eOPnsy5oaRYuatR7Fw2SJ4kKforgufeo7fq0EQ==",
+      "version": "1.5.400",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.400.tgz",
+      "integrity": "sha512-96EWDNjM59SYflgeV5Ylsf4EMiq1a25YjCnJH7cxn/AF2H3pILRweaUnoLax0yKHWdpOzY6JKEu45e8irqZIHA==",
       "license": "ISC"
     },
     "node_modules/enhanced-resolve": {
-      "version": "5.24.3",
-      "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.24.3.tgz",
-      "integrity": "sha512-PwKooW9JUzh5chmYfHM3IQl5OkK2u2Nm011MgeZrss3JmFraUx/fqrf78kk8GUMYoibx/14MdwTl/1WKkG7TpQ==",
+      "version": "5.24.5",
+      "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.24.5.tgz",
+      "integrity": "sha512-L1l8TNvomm6UVW5B253AGxQagSQr+vGwhMlrrfRS2qmhx46AMpMVJKQYLvWYbysTMY8VoicOvzHzoHMbyzB+4A==",
       "license": "MIT",
       "dependencies": {
         "graceful-fs": "^4.2.4",
@@ -3264,9 +3273,9 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
-      "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.1.tgz",
+      "integrity": "sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==",
       "funding": [
         {
           "type": "github",
@@ -3357,12 +3366,6 @@
         "type": "opencollective",
         "url": "https://opencollective.com/webpack"
       }
-    },
-    "node_modules/lodash.sortby": {
-      "version": "4.7.0",
-      "resolved": "https://registry.npmjs.org/lodash.sortby/-/lodash.sortby-4.7.0.tgz",
-      "integrity": "sha512-HDWXG8isMntAyRF5vZ7xKuEvOhT4AhlRt/3czTSjvGUxjYCBVRQY48ViDHyfYz9VIoBkW4TMGQNapx+l3RUwdA==",
-      "license": "MIT"
     },
     "node_modules/lower-case": {
       "version": "2.0.2",
@@ -3461,9 +3464,9 @@
       "license": "MIT"
     },
     "node_modules/nanoid": {
-      "version": "3.3.16",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
-      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
+      "version": "3.3.17",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.17.tgz",
+      "integrity": "sha512-xQLf0A3HOMlgHq0n247/LRuAOYmB7dXJ/DvAxGvsSBij45XtBSmQycu+F8ODbHwns/XyFZagyL1+J0Offw1E0g==",
       "funding": [
         {
           "type": "github",
@@ -3495,9 +3498,9 @@
       }
     },
     "node_modules/node-releases": {
-      "version": "2.0.51",
-      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.51.tgz",
-      "integrity": "sha512-wRNIrw4DmVLKQlbgOMdkMx27Wrpzes2hh5Jtbi2bjPd+4wJstWIqP5A+lscnqbm0xxmT5Bpg8Lec5ItEBwx6BQ==",
+      "version": "2.0.52",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.52.tgz",
+      "integrity": "sha512-MRlTqhAfoMx/4mhEbPo3Hi02g9LJZaJkka69V6h67Cb1gjrAG0jsTE4CZX1eptNx+VCAwJmfpnDIF4P0Nh1A7A==",
       "license": "MIT",
       "engines": {
         "node": ">=18"
@@ -3602,9 +3605,9 @@
       "license": "ISC"
     },
     "node_modules/postcss": {
-      "version": "8.5.23",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.23.tgz",
-      "integrity": "sha512-g50586zr4bZmwFiTlflMu8E0bDTb5I5gertgwAKmsdUlTQIhZtunzUlD1WSzwcVWPoAVpsrA6vlfCD7oXvRwgg==",
+      "version": "8.5.25",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.25.tgz",
+      "integrity": "sha512-DTPx3RWSSnWyzLxQnlH0rJP+EW5ekl16ZU4/psbIhA0e53kJfdgaN5vKM+xP7yJtXVu+nfdVFmlgFDEKAe4Pyw==",
       "funding": [
         {
           "type": "opencollective",
@@ -3735,34 +3738,25 @@
         "node": ">= 6"
       }
     },
-    "node_modules/punycode": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
-      "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=6"
-      }
-    },
     "node_modules/react": {
-      "version": "19.2.7",
-      "resolved": "https://registry.npmjs.org/react/-/react-19.2.7.tgz",
-      "integrity": "sha512-HNe9WslTbXmFK8o8cmwgAeJFSBvt1bPdHCVKtaaV+WlAN36mpT4hcRpwbf3fY56ar2oIXzsBpOAiIRHAdY0OlQ==",
+      "version": "19.2.8",
+      "resolved": "https://registry.npmjs.org/react/-/react-19.2.8.tgz",
+      "integrity": "sha512-PWaYA1L/q9u2u7xYQi+Y3L3Yfnie7XyLeaJICV1MGD6LprsBxcAqGjYyr0eY3p+QdsA+x/Irkt4Qif8D63+Sbw==",
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
       }
     },
     "node_modules/react-dom": {
-      "version": "19.2.7",
-      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.7.tgz",
-      "integrity": "sha512-t0BRVXvbiE/o20Hfw669rLbMCDWtYZLvmJigy2f0MxsXF+71pxhR3xOkspmsO8h3ZlNzyibAmtCa3l4lYKk6gQ==",
+      "version": "19.2.8",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.8.tgz",
+      "integrity": "sha512-rVprimfGBG3DR+Tq0IQG2DT5PxKth1WIGDmj5yPmlzr4YBe7uyE+Du4oVqTDXZSHGGGXRtTJEGSSePyQCMBglQ==",
       "license": "MIT",
       "dependencies": {
         "scheduler": "^0.27.0"
       },
       "peerDependencies": {
-        "react": "^19.2.7"
+        "react": "^19.2.8"
       }
     },
     "node_modules/react-refresh": {
@@ -3800,9 +3794,9 @@
       }
     },
     "node_modules/remotion": {
-      "version": "4.0.499",
-      "resolved": "https://registry.npmjs.org/remotion/-/remotion-4.0.499.tgz",
-      "integrity": "sha512-QX5B1XDFBQpr8mYUBqhgCrH0cQJmqfI7zA46k9CsZhri/H9quXObYQBgeNDcxUhoulVvOOjVQqp5d0RAwB94HA==",
+      "version": "4.0.505",
+      "resolved": "https://registry.npmjs.org/remotion/-/remotion-4.0.505.tgz",
+      "integrity": "sha512-Lhi03pimw+Tcer2C0iioJD3c5Iy5hmRJRHtR9XvObhKl0Z4Lpi/EDeTFq1tvU9VVeezU75tVlHYeq+S3TDIiPw==",
       "license": "SEE LICENSE IN LICENSE.md",
       "peerDependencies": {
         "react": ">=16.8.0",
@@ -3992,16 +3986,12 @@
       }
     },
     "node_modules/source-map": {
-      "version": "0.8.0-beta.0",
-      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.8.0-beta.0.tgz",
-      "integrity": "sha512-2ymg6oRBpebeZi9UUNsgQ89bhx01TcTkmNTGnNO88imTmbSgy4nfujrgVEFKWpMTEGA11EDkTt7mqObTPdigIA==",
-      "deprecated": "The work that was done in this beta branch won't be included in future versions",
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.8.0.tgz",
+      "integrity": "sha512-d8EqvL+k/SOXCreS/SUzg2ciyHqBBLcN/yuRjFsbvVhHTE2pgei7oAhmPM7kWFbkX6OSMQfUq4KbkF3au9lhYQ==",
       "license": "BSD-3-Clause",
-      "dependencies": {
-        "whatwg-url": "^7.0.0"
-      },
       "engines": {
-        "node": ">= 8"
+        "node": ">= 12"
       }
     },
     "node_modules/source-map-js": {
@@ -4098,9 +4088,9 @@
       }
     },
     "node_modules/terser": {
-      "version": "5.49.0",
-      "resolved": "https://registry.npmjs.org/terser/-/terser-5.49.0.tgz",
-      "integrity": "sha512-SNiDnXyHSrxVcIOtVbULzcTmniUiwcV7Nwdyj1twVubeTmbjoa8p69KKDpfkdoOavuM4/GRm1+ykI8qqnavHoA==",
+      "version": "5.49.1",
+      "resolved": "https://registry.npmjs.org/terser/-/terser-5.49.1.tgz",
+      "integrity": "sha512-7A2xlQ5EnGT8KPA92dUh6RbRYTVw8hEaEN9L1K68l4UOXFuV511NnAqObGoRqGOQofQcMypisu1s3xawCEHrvA==",
       "license": "BSD-2-Clause",
       "dependencies": {
         "@jridgewell/source-map": "^0.3.3",
@@ -4190,15 +4180,6 @@
         "node": ">=4"
       }
     },
-    "node_modules/tr46": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/tr46/-/tr46-1.0.1.tgz",
-      "integrity": "sha512-dTpowEjclQ7Kgx5SdBkqRzVhERQXov8/l9Ft9dVM9fmg0W0KQSVaXX9T4i6twCPNtYiZM53lpSSUAwJbFPOHxA==",
-      "license": "MIT",
-      "dependencies": {
-        "punycode": "^2.1.0"
-      }
-    },
     "node_modules/tslib": {
       "version": "2.8.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
@@ -4273,12 +4254,6 @@
         "node": ">=10.13.0"
       }
     },
-    "node_modules/webidl-conversions": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-4.0.2.tgz",
-      "integrity": "sha512-YQ+BmxuTgd6UXZW3+ICGfyqRyHXVlD5GtQr5+qjiNW7bF0cqrzX500HVXPBOvgXb5YnzDd+h0zqyv61KUD7+Sg==",
-      "license": "BSD-2-Clause"
-    },
     "node_modules/webpack": {
       "version": "5.105.0",
       "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.105.0.tgz",
@@ -4334,17 +4309,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=10.13.0"
-      }
-    },
-    "node_modules/whatwg-url": {
-      "version": "7.1.0",
-      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-7.1.0.tgz",
-      "integrity": "sha512-WUu7Rg1DroM7oQvGWfOiAK21n74Gg+T4elXEQYkOhtyLeWiJFoOGLXPKI/9gzIie9CtwVLm8wtw6YJdKyxSjeg==",
-      "license": "MIT",
-      "dependencies": {
-        "lodash.sortby": "^4.7.0",
-        "tr46": "^1.0.1",
-        "webidl-conversions": "^4.0.2"
       }
     },
     "node_modules/which": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "paper-collage-video-pipeline",
-  "version": "0.19.0",
+  "version": "0.19.1-dev.1",
   "description": "Configuration-driven paper-collage video pipeline and Codex plugin built with Remotion.",
   "private": true,
   "type": "module",
@@ -106,14 +106,14 @@
     "fast-uri": "3.1.5"
   },
   "dependencies": {
-    "@remotion/cli": "4.0.499",
-    "react": "19.2.7",
-    "react-dom": "19.2.7",
-    "remotion": "4.0.499"
+    "@remotion/cli": "4.0.505",
+    "react": "19.2.8",
+    "react-dom": "19.2.8",
+    "remotion": "4.0.505"
   },
   "devDependencies": {
-    "@types/react": "19.2.17",
-    "@types/react-dom": "19.2.3",
+    "@types/react": "19.2.18",
+    "@types/react-dom": "19.2.4",
     "sharp": "0.35.3",
     "typescript": "5.9.3"
   }

--- a/plugins/paper-collage-video/.codex-plugin/plugin.json
+++ b/plugins/paper-collage-video/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "paper-collage-video",
-  "version": "0.19.0",
+  "version": "0.19.1-dev.1",
   "description": "Create editable paper-collage, illustrated, and comic-inspired videos with executable style and whole-film motion contracts, dynamic visual intake cards, costed planning scenarios, registered asset families, and proof-backed rendering.",
   "author": {
     "name": "Paper Collage Video Contributors"

--- a/plugins/paper-collage-video/assets/remotion-template/.paper-collage-template.json
+++ b/plugins/paper-collage-video/assets/remotion-template/.paper-collage-template.json
@@ -1,5 +1,5 @@
 {
   "schemaVersion": 1,
   "plugin": "paper-collage-video",
-  "pluginVersion": "0.19.0"
+  "pluginVersion": "0.19.1-dev.1"
 }

--- a/plugins/paper-collage-video/assets/remotion-template/dist/starter-demo/assets-ready-seal.json
+++ b/plugins/paper-collage-video/assets/remotion-template/dist/starter-demo/assets-ready-seal.json
@@ -2,14 +2,14 @@
   "schemaVersion": 1,
   "projectSlug": "starter-demo",
   "generatedAt": "2026-01-01T00:00:00.000Z",
-  "fingerprint": "e0c186329f3085c132d315788423fa399d2d4da178e30522daca63382515207a",
+  "fingerprint": "f59c8a1db7815789fc0b01835f413b7366787cfd49388d096c95ee48b1fe7821",
   "basis": {
     "projectSlug": "starter-demo",
-    "visualFingerprint": "6cd31d543f67f0b32901427dd8925521b536c13d81f7ec0e9720930e3fba2344",
-    "audioFingerprint": "d596ab5d25be79f1fd103ad5f596569e064a979938925742e2b1414a0a93f65e",
+    "visualFingerprint": "8e3ed7a656f6d37df0c626a573e4ded6a198f4707ac24971e1a85cbbc4e15502",
+    "audioFingerprint": "47ab2ef6170a62bc66e231d4c2968ff8c0b7e8155505a4889bb1d6dd54636d20",
     "storyboardFingerprint": "8ebcc6c57f07a2a0bad8a1452a562f847ad3b2fc903be534f2ede3c02d1d1239",
     "validationFingerprint": "0c42fc1295c254a0683a36c319a72154fd8b2d07c06c1e9a2b454f4b8c42b0fd",
-    "qualityFingerprint": "2db64f8d4eae9a3ddeb1f318322cfa42b2234eb4f72e5b55e682cc1ba45e114a",
+    "qualityFingerprint": "457260189e7aad641e3c05ba7bf98be6712269e9c117a5bc5f0b28a1e2b42c66",
     "subtitleFingerprint": "6b196c02d311c1ac0f7d728263db0259cd1724adade7cc1a61d7ee09cddff52c",
     "subtitleContract": {
       "schemaVersion": 1,

--- a/plugins/paper-collage-video/assets/remotion-template/dist/starter-demo/composition-proof/report.json
+++ b/plugins/paper-collage-video/assets/remotion-template/dist/starter-demo/composition-proof/report.json
@@ -30,7 +30,7 @@
       "compositeId": "event:starter:establish",
       "sceneId": "starter",
       "pattern": "event",
-      "fingerprint": "785bfb0a7944e9f3ad06f360cda8f0e4612bd6099bd06f3d590aa9df68b8092c",
+      "fingerprint": "e11a4aef6c55328e53ca6cffcb33e01622ad9942bbd708f06d577a97a43ec16a",
       "proofFrames": [
         {
           "sceneId": "starter",
@@ -53,7 +53,7 @@
       "compositeId": "event:starter:subject-arrives",
       "sceneId": "starter",
       "pattern": "event",
-      "fingerprint": "3a0368804159f91798ee0eda4fcd03b2820395db5093dce76549a8d75980319e",
+      "fingerprint": "bccdd4d0417cbab90d867834713e18110f6be786fe3b7486c82ca59763594fa0",
       "proofFrames": [
         {
           "sceneId": "starter",
@@ -76,7 +76,7 @@
       "compositeId": "event:starter:lockup",
       "sceneId": "starter",
       "pattern": "event",
-      "fingerprint": "43952d84d31ce025b6f07f00ecd0c5182d629a2360b12c96a182cdd0ce768c18",
+      "fingerprint": "01b806cd5efce473cef2827d03ea03cc83ba6d0855f0cd52bd7fe583d8e7c2a5",
       "proofFrames": [
         {
           "sceneId": "starter",
@@ -99,7 +99,7 @@
       "compositeId": "style-profile:childrens-picture-book-paper",
       "sceneId": "starter",
       "pattern": "style-target",
-      "fingerprint": "83a36232e4768e96811b449b95b7da710d15d88172efd6b5c8bd2e68e41bd555",
+      "fingerprint": "df6737ab836ff666897f50f01bd6e5438c0ae5a7bc48dad67696c0fb03f699ca",
       "proofFrames": [
         {
           "sceneId": "starter",
@@ -152,7 +152,7 @@
       "compositeId": "motion-contract:whole-film",
       "sceneId": "starter",
       "pattern": "motion-contract",
-      "fingerprint": "feec12f2e7106a93b57784afdca59e35b95882d69c729503207fffdffef69dfb",
+      "fingerprint": "4ee9fd9bfd17afaabd8511067271ef552a22d639abf3248d92aec821dbc928d9",
       "proofFrames": [
         {
           "sceneId": "starter",

--- a/plugins/paper-collage-video/assets/remotion-template/package-lock.json
+++ b/plugins/paper-collage-video/assets/remotion-template/package-lock.json
@@ -1,22 +1,22 @@
 {
   "name": "paper-collage-video-workspace",
-  "version": "0.19.0",
+  "version": "0.19.1-dev.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "paper-collage-video-workspace",
-      "version": "0.19.0",
+      "version": "0.19.1-dev.1",
       "license": "MIT",
       "dependencies": {
-        "@remotion/cli": "4.0.499",
-        "react": "19.2.7",
-        "react-dom": "19.2.7",
-        "remotion": "4.0.499"
+        "@remotion/cli": "4.0.505",
+        "react": "19.2.8",
+        "react-dom": "19.2.8",
+        "remotion": "4.0.505"
       },
       "devDependencies": {
-        "@types/react": "19.2.17",
-        "@types/react-dom": "19.2.3",
+        "@types/react": "19.2.18",
+        "@types/react-dom": "19.2.4",
         "sharp": "0.35.3",
         "typescript": "5.9.3"
       },
@@ -78,12 +78,12 @@
       }
     },
     "node_modules/@babel/core/node_modules/@babel/parser": {
-      "version": "7.29.7",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.7.tgz",
-      "integrity": "sha512-hnORnjP/1P/zFEndoeX+n+t1RwWRJiJpM/jO7FW32Kn9r5+sJB2JWOdYo4L6k78j15eCwY3Gm/7364B1EMwtNg==",
+      "version": "7.29.8",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.8.tgz",
+      "integrity": "sha512-E8lTAYNB1KW+FH+VGJuZM1ioAx2E6oVlvQFRrf5P8ZZmsiJXYAD9vTFV7yyEURNzgh1dFqMZuO6tUwcARbqFCA==",
       "license": "MIT",
       "dependencies": {
-        "@babel/types": "^7.29.7"
+        "@babel/types": "^7.29.8"
       },
       "bin": {
         "parser": "bin/babel-parser.js"
@@ -93,9 +93,9 @@
       }
     },
     "node_modules/@babel/core/node_modules/@babel/types": {
-      "version": "7.29.7",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.7.tgz",
-      "integrity": "sha512-4zBIxpPzowiZpusoFkyGVwakdRJUyuH5PxQ/PrqghfdFWWasvnCdPfQXHrenDai+gyLARulZjZowCOj6fjT4pA==",
+      "version": "7.29.8",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.8.tgz",
+      "integrity": "sha512-Vj1jF3cPfxg7OAfoI7QnVKLoILlm2JF9pnVHrX8qx7AHMiYWT+NDAA7jChlNgRS4WTLc/fD1lXLmPixluj+3Gg==",
       "license": "MIT",
       "dependencies": {
         "@babel/helper-string-parser": "^7.29.7",
@@ -115,13 +115,13 @@
       }
     },
     "node_modules/@babel/generator": {
-      "version": "7.29.7",
-      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.29.7.tgz",
-      "integrity": "sha512-DkXD5OJQaAQIdZ1bt3UZdEnHAn9Imd3IVBdX03UFe+ony9Ojw5pzr9YVKGDY1jt+Gcn/FnGkNf8r+Vj5NOJWtQ==",
+      "version": "7.29.8",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.29.8.tgz",
+      "integrity": "sha512-gZbepsdh3WDtgZKWL+vTPh71LSBrm/Y4/QDZBVCcYfmeTEEuoOYwlSy+G1StfJg+/Zy550u/3TATbm7qDbbMtg==",
       "license": "MIT",
       "dependencies": {
-        "@babel/parser": "^7.29.7",
-        "@babel/types": "^7.29.7",
+        "@babel/parser": "^7.29.8",
+        "@babel/types": "^7.29.8",
         "@jridgewell/gen-mapping": "^0.3.12",
         "@jridgewell/trace-mapping": "^0.3.28",
         "jsesc": "^3.0.2"
@@ -131,12 +131,12 @@
       }
     },
     "node_modules/@babel/generator/node_modules/@babel/parser": {
-      "version": "7.29.7",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.7.tgz",
-      "integrity": "sha512-hnORnjP/1P/zFEndoeX+n+t1RwWRJiJpM/jO7FW32Kn9r5+sJB2JWOdYo4L6k78j15eCwY3Gm/7364B1EMwtNg==",
+      "version": "7.29.8",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.8.tgz",
+      "integrity": "sha512-E8lTAYNB1KW+FH+VGJuZM1ioAx2E6oVlvQFRrf5P8ZZmsiJXYAD9vTFV7yyEURNzgh1dFqMZuO6tUwcARbqFCA==",
       "license": "MIT",
       "dependencies": {
-        "@babel/types": "^7.29.7"
+        "@babel/types": "^7.29.8"
       },
       "bin": {
         "parser": "bin/babel-parser.js"
@@ -146,9 +146,9 @@
       }
     },
     "node_modules/@babel/generator/node_modules/@babel/types": {
-      "version": "7.29.7",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.7.tgz",
-      "integrity": "sha512-4zBIxpPzowiZpusoFkyGVwakdRJUyuH5PxQ/PrqghfdFWWasvnCdPfQXHrenDai+gyLARulZjZowCOj6fjT4pA==",
+      "version": "7.29.8",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.8.tgz",
+      "integrity": "sha512-Vj1jF3cPfxg7OAfoI7QnVKLoILlm2JF9pnVHrX8qx7AHMiYWT+NDAA7jChlNgRS4WTLc/fD1lXLmPixluj+3Gg==",
       "license": "MIT",
       "dependencies": {
         "@babel/helper-string-parser": "^7.29.7",
@@ -206,9 +206,9 @@
       }
     },
     "node_modules/@babel/helper-module-imports/node_modules/@babel/types": {
-      "version": "7.29.7",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.7.tgz",
-      "integrity": "sha512-4zBIxpPzowiZpusoFkyGVwakdRJUyuH5PxQ/PrqghfdFWWasvnCdPfQXHrenDai+gyLARulZjZowCOj6fjT4pA==",
+      "version": "7.29.8",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.8.tgz",
+      "integrity": "sha512-Vj1jF3cPfxg7OAfoI7QnVKLoILlm2JF9pnVHrX8qx7AHMiYWT+NDAA7jChlNgRS4WTLc/fD1lXLmPixluj+3Gg==",
       "license": "MIT",
       "dependencies": {
         "@babel/helper-string-parser": "^7.29.7",
@@ -276,9 +276,9 @@
       }
     },
     "node_modules/@babel/helpers/node_modules/@babel/types": {
-      "version": "7.29.7",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.7.tgz",
-      "integrity": "sha512-4zBIxpPzowiZpusoFkyGVwakdRJUyuH5PxQ/PrqghfdFWWasvnCdPfQXHrenDai+gyLARulZjZowCOj6fjT4pA==",
+      "version": "7.29.8",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.8.tgz",
+      "integrity": "sha512-Vj1jF3cPfxg7OAfoI7QnVKLoILlm2JF9pnVHrX8qx7AHMiYWT+NDAA7jChlNgRS4WTLc/fD1lXLmPixluj+3Gg==",
       "license": "MIT",
       "dependencies": {
         "@babel/helper-string-parser": "^7.29.7",
@@ -315,12 +315,12 @@
       }
     },
     "node_modules/@babel/template/node_modules/@babel/parser": {
-      "version": "7.29.7",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.7.tgz",
-      "integrity": "sha512-hnORnjP/1P/zFEndoeX+n+t1RwWRJiJpM/jO7FW32Kn9r5+sJB2JWOdYo4L6k78j15eCwY3Gm/7364B1EMwtNg==",
+      "version": "7.29.8",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.8.tgz",
+      "integrity": "sha512-E8lTAYNB1KW+FH+VGJuZM1ioAx2E6oVlvQFRrf5P8ZZmsiJXYAD9vTFV7yyEURNzgh1dFqMZuO6tUwcARbqFCA==",
       "license": "MIT",
       "dependencies": {
-        "@babel/types": "^7.29.7"
+        "@babel/types": "^7.29.8"
       },
       "bin": {
         "parser": "bin/babel-parser.js"
@@ -330,9 +330,9 @@
       }
     },
     "node_modules/@babel/template/node_modules/@babel/types": {
-      "version": "7.29.7",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.7.tgz",
-      "integrity": "sha512-4zBIxpPzowiZpusoFkyGVwakdRJUyuH5PxQ/PrqghfdFWWasvnCdPfQXHrenDai+gyLARulZjZowCOj6fjT4pA==",
+      "version": "7.29.8",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.8.tgz",
+      "integrity": "sha512-Vj1jF3cPfxg7OAfoI7QnVKLoILlm2JF9pnVHrX8qx7AHMiYWT+NDAA7jChlNgRS4WTLc/fD1lXLmPixluj+3Gg==",
       "license": "MIT",
       "dependencies": {
         "@babel/helper-string-parser": "^7.29.7",
@@ -343,17 +343,17 @@
       }
     },
     "node_modules/@babel/traverse": {
-      "version": "7.29.7",
-      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.29.7.tgz",
-      "integrity": "sha512-EhlfNQtZ+NK22w5BM61ciuiq1m58ed33Wr1Xan//ZRTy6hgjnwyCffRYwzsGXdASJSUJ1guZILsErh1eQcl+zw==",
+      "version": "7.29.8",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.29.8.tgz",
+      "integrity": "sha512-I5z7H3bf/41ktsNVLtpN0wAa336HkqIHQ5BuPLEhTkt1jVSyZpeNKIzTgEWmlxjdg81R0IgUCcaE+Ok3NvrfZg==",
       "license": "MIT",
       "dependencies": {
         "@babel/code-frame": "^7.29.7",
-        "@babel/generator": "^7.29.7",
+        "@babel/generator": "^7.29.8",
         "@babel/helper-globals": "^7.29.7",
-        "@babel/parser": "^7.29.7",
+        "@babel/parser": "^7.29.8",
         "@babel/template": "^7.29.7",
-        "@babel/types": "^7.29.7",
+        "@babel/types": "^7.29.8",
         "debug": "^4.3.1"
       },
       "engines": {
@@ -361,12 +361,12 @@
       }
     },
     "node_modules/@babel/traverse/node_modules/@babel/parser": {
-      "version": "7.29.7",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.7.tgz",
-      "integrity": "sha512-hnORnjP/1P/zFEndoeX+n+t1RwWRJiJpM/jO7FW32Kn9r5+sJB2JWOdYo4L6k78j15eCwY3Gm/7364B1EMwtNg==",
+      "version": "7.29.8",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.8.tgz",
+      "integrity": "sha512-E8lTAYNB1KW+FH+VGJuZM1ioAx2E6oVlvQFRrf5P8ZZmsiJXYAD9vTFV7yyEURNzgh1dFqMZuO6tUwcARbqFCA==",
       "license": "MIT",
       "dependencies": {
-        "@babel/types": "^7.29.7"
+        "@babel/types": "^7.29.8"
       },
       "bin": {
         "parser": "bin/babel-parser.js"
@@ -376,9 +376,9 @@
       }
     },
     "node_modules/@babel/traverse/node_modules/@babel/types": {
-      "version": "7.29.7",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.7.tgz",
-      "integrity": "sha512-4zBIxpPzowiZpusoFkyGVwakdRJUyuH5PxQ/PrqghfdFWWasvnCdPfQXHrenDai+gyLARulZjZowCOj6fjT4pA==",
+      "version": "7.29.8",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.8.tgz",
+      "integrity": "sha512-Vj1jF3cPfxg7OAfoI7QnVKLoILlm2JF9pnVHrX8qx7AHMiYWT+NDAA7jChlNgRS4WTLc/fD1lXLmPixluj+3Gg==",
       "license": "MIT",
       "dependencies": {
         "@babel/helper-string-parser": "^7.29.7",
@@ -414,9 +414,9 @@
       }
     },
     "node_modules/@emnapi/runtime": {
-      "version": "1.11.2",
-      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.11.2.tgz",
-      "integrity": "sha512-kyOl3X0DuTiT1h2ft8r2fYO8JYtU9a9Xis/zBSiGArNaagCOWx90N1k2wxp18czFDH+OgcWGb5ZP/XMt3dcyPA==",
+      "version": "1.11.3",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.11.3.tgz",
+      "integrity": "sha512-Xz4Tpyki7XyrpbUK1jR1AhdAdaXyhhY4lZ3neLodmhpuWfy2PAQN5B46sAiU4liOXGLkHypn/qU+jvfWSCYYLA==",
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -1536,21 +1536,21 @@
       }
     },
     "node_modules/@remotion/bundler": {
-      "version": "4.0.499",
-      "resolved": "https://registry.npmjs.org/@remotion/bundler/-/bundler-4.0.499.tgz",
-      "integrity": "sha512-88C7WxlC9DSxEOSnJL/HV7Xl16OIKnEzl90BvIM083pNBA/laAEJvryaXmSQ3FuI5CSGuVA336YgboOWagqmAg==",
+      "version": "4.0.505",
+      "resolved": "https://registry.npmjs.org/@remotion/bundler/-/bundler-4.0.505.tgz",
+      "integrity": "sha512-yAq9iliYeHB3qp3Jl1w829lwHwlY6C2UF8d1hPHaMjFWiHRHikR5al9BHtVSrYC4yIQmNXJTGPNjgC9GCteFtQ==",
       "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
-        "@remotion/media-parser": "4.0.499",
-        "@remotion/studio": "4.0.499",
-        "@remotion/studio-shared": "4.0.499",
-        "@remotion/timeline-utils": "4.0.499",
+        "@remotion/media-parser": "4.0.505",
+        "@remotion/studio": "4.0.505",
+        "@remotion/studio-shared": "4.0.505",
+        "@remotion/timeline-utils": "4.0.505",
         "@rspack/core": "1.7.11",
         "@rspack/plugin-react-refresh": "1.6.1",
         "css-loader": "7.1.4",
         "esbuild": "0.28.1",
         "react-refresh": "0.18.0",
-        "remotion": "4.0.499",
+        "remotion": "4.0.505",
         "style-loader": "4.0.0",
         "webpack": "5.105.0"
       },
@@ -1559,37 +1559,30 @@
         "react-dom": ">=16.8.0"
       }
     },
-    "node_modules/@remotion/canvas-capture": {
-      "version": "4.0.499",
-      "resolved": "https://registry.npmjs.org/@remotion/canvas-capture/-/canvas-capture-4.0.499.tgz",
-      "integrity": "sha512-S2Q5eqNnjkRmxm5FZMadI21bPuLyKa2+zRLh3c2EDjRS1C400rx19UCmG1Ne9W38ybInm/MohcLS3EkaNHZqrw==",
-      "license": "Remotion License",
-      "dependencies": {
-        "mediabunny": "1.50.8",
-        "remotion": "4.0.499"
-      },
-      "peerDependencies": {
-        "react": ">=16.8.0",
-        "react-dom": ">=16.8.0"
-      }
+    "node_modules/@remotion/captions": {
+      "version": "4.0.505",
+      "resolved": "https://registry.npmjs.org/@remotion/captions/-/captions-4.0.505.tgz",
+      "integrity": "sha512-wS5jM6/rKj6JPT9h0lDl0nbaOOs1hje/jHjvIturjX5IuEPlx6HVcDzcT/+hP6AXkYddGd/DUmZ3T/8S/zjMRg==",
+      "license": "MIT"
     },
     "node_modules/@remotion/cli": {
-      "version": "4.0.499",
-      "resolved": "https://registry.npmjs.org/@remotion/cli/-/cli-4.0.499.tgz",
-      "integrity": "sha512-IOscAgjRECQhwUaXEFBc3x6FvRaEcQNyx3qGxyprPL+K3xwmfTVJgYI8igMQZUgEUxtwdDQ2hjMUB+30wgxa1g==",
+      "version": "4.0.505",
+      "resolved": "https://registry.npmjs.org/@remotion/cli/-/cli-4.0.505.tgz",
+      "integrity": "sha512-6YBzX/H060PPC2MqLLEWSfj0pSeEDY4coVSH7BAtrRANJNjVArfMWS3cmGcKhXLIV+wvwcTm6HhPRcJAeq7LBw==",
       "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
-        "@remotion/bundler": "4.0.499",
-        "@remotion/media-utils": "4.0.499",
-        "@remotion/player": "4.0.499",
-        "@remotion/renderer": "4.0.499",
-        "@remotion/studio": "4.0.499",
-        "@remotion/studio-server": "4.0.499",
-        "@remotion/studio-shared": "4.0.499",
+        "@remotion/bundler": "4.0.505",
+        "@remotion/media-utils": "4.0.505",
+        "@remotion/player": "4.0.505",
+        "@remotion/renderer": "4.0.505",
+        "@remotion/studio": "4.0.505",
+        "@remotion/studio-server": "4.0.505",
+        "@remotion/studio-shared": "4.0.505",
         "dotenv": "17.3.1",
         "minimist": "1.2.6",
         "prompts": "2.4.2",
-        "remotion": "4.0.499"
+        "remotion": "4.0.505",
+        "semver": "7.5.3"
       },
       "bin": {
         "remotion": "remotion-cli.js",
@@ -1602,9 +1595,9 @@
       }
     },
     "node_modules/@remotion/compositor-darwin-arm64": {
-      "version": "4.0.499",
-      "resolved": "https://registry.npmjs.org/@remotion/compositor-darwin-arm64/-/compositor-darwin-arm64-4.0.499.tgz",
-      "integrity": "sha512-7pBC1NwnzFFHRmCIx0DlRMb53SIwGb24Abx28f3wSdrgYVAU9A0Ema/Y+h0dZVGIwC3RO0iUQgs3h8ra7XVB6Q==",
+      "version": "4.0.505",
+      "resolved": "https://registry.npmjs.org/@remotion/compositor-darwin-arm64/-/compositor-darwin-arm64-4.0.505.tgz",
+      "integrity": "sha512-ULBrt1pbv8oRhpozIxHhlShWqf8SYxuAg7mjRAfp0k3dJT5OCljhg//Zbl60Wsz9nQQvB+0/pAhyXvsEIWAm6Q==",
       "cpu": [
         "arm64"
       ],
@@ -1614,9 +1607,9 @@
       ]
     },
     "node_modules/@remotion/compositor-darwin-x64": {
-      "version": "4.0.499",
-      "resolved": "https://registry.npmjs.org/@remotion/compositor-darwin-x64/-/compositor-darwin-x64-4.0.499.tgz",
-      "integrity": "sha512-gFGYRH7CRIqhOuxQDGnIoHCEMhUeu7zJWuA/fy0hPPnWayDMsWChfY9+yGHsWGBePbNdXEM2HBcuC4RxDLORtQ==",
+      "version": "4.0.505",
+      "resolved": "https://registry.npmjs.org/@remotion/compositor-darwin-x64/-/compositor-darwin-x64-4.0.505.tgz",
+      "integrity": "sha512-nRllcfW9ifW7yvgQj3hXY8pjGhisWc0p3NokLgvRAu3CcJc1KXHJVu9BP1TgTnjx69KaRii/GtltQVXC+J/xhg==",
       "cpu": [
         "x64"
       ],
@@ -1626,9 +1619,9 @@
       ]
     },
     "node_modules/@remotion/compositor-linux-arm64-gnu": {
-      "version": "4.0.499",
-      "resolved": "https://registry.npmjs.org/@remotion/compositor-linux-arm64-gnu/-/compositor-linux-arm64-gnu-4.0.499.tgz",
-      "integrity": "sha512-aLSwT8857xWuPaYFDSOVPSVp6efXnPYS8MEUdKQdCoqXNpgufugCAGL/xzagPo2A3wD+Ocuzj6+bcsBna3ivMg==",
+      "version": "4.0.505",
+      "resolved": "https://registry.npmjs.org/@remotion/compositor-linux-arm64-gnu/-/compositor-linux-arm64-gnu-4.0.505.tgz",
+      "integrity": "sha512-++UMpFFRAqNr3iGgtnOqOgSpH8Hf8zCpG1K8LFKp/o2MEq7q3s239TXFHNrgUFMUJ/HXio5PS9X238Nx24mD0Q==",
       "cpu": [
         "arm64"
       ],
@@ -1638,9 +1631,9 @@
       ]
     },
     "node_modules/@remotion/compositor-linux-arm64-musl": {
-      "version": "4.0.499",
-      "resolved": "https://registry.npmjs.org/@remotion/compositor-linux-arm64-musl/-/compositor-linux-arm64-musl-4.0.499.tgz",
-      "integrity": "sha512-bC3/NocB8FUiieUBZtE2A19sr34cLDHo5r0Q1aUevsI/RpJkq9LYJzmifMgO+8OxVxv4nxg8cSryHrDpEsylZQ==",
+      "version": "4.0.505",
+      "resolved": "https://registry.npmjs.org/@remotion/compositor-linux-arm64-musl/-/compositor-linux-arm64-musl-4.0.505.tgz",
+      "integrity": "sha512-ouIlMngzE2lLyaBEBFS8curBeigqBnz2PvXKIbluAwWSRuDgBM10i6Ya4D5Q3VWJNaqNgaDfxET4b+/RPFd7Hw==",
       "cpu": [
         "arm64"
       ],
@@ -1650,9 +1643,9 @@
       ]
     },
     "node_modules/@remotion/compositor-linux-x64-gnu": {
-      "version": "4.0.499",
-      "resolved": "https://registry.npmjs.org/@remotion/compositor-linux-x64-gnu/-/compositor-linux-x64-gnu-4.0.499.tgz",
-      "integrity": "sha512-I9aOX1tpdSwi+jwYcZjg0V8jnp0eVKBWe6iaD3V85USrxxFu4LdvHwJ+Lh6kWC7L1mlrlrac9AGkZm70AoBvWQ==",
+      "version": "4.0.505",
+      "resolved": "https://registry.npmjs.org/@remotion/compositor-linux-x64-gnu/-/compositor-linux-x64-gnu-4.0.505.tgz",
+      "integrity": "sha512-Byyq9lnlxtfTvNmYKoB83GJjS4u26vrOYczgxb1DusISWBijMcG9oVjmYCNI5wdqEuhnEPAAAK7zoGzxA9B6pQ==",
       "cpu": [
         "x64"
       ],
@@ -1662,9 +1655,9 @@
       ]
     },
     "node_modules/@remotion/compositor-linux-x64-musl": {
-      "version": "4.0.499",
-      "resolved": "https://registry.npmjs.org/@remotion/compositor-linux-x64-musl/-/compositor-linux-x64-musl-4.0.499.tgz",
-      "integrity": "sha512-pDBDfyuaVBueuIqd88SSdCerSzixm3toZZfLbS4ACxLUqtGJshRcmuFeWiaUALSbtwa4KIPMPzgPGCu5cmnuRA==",
+      "version": "4.0.505",
+      "resolved": "https://registry.npmjs.org/@remotion/compositor-linux-x64-musl/-/compositor-linux-x64-musl-4.0.505.tgz",
+      "integrity": "sha512-9wV5K/bN0MbW4ZOYj5yVjo4SIBQf2QzP+IBin9Rt7/uoBh9i2qSENiaXY9lX52rPn9nuYjx3ww7Btxx1br4hqg==",
       "cpu": [
         "x64"
       ],
@@ -1674,9 +1667,9 @@
       ]
     },
     "node_modules/@remotion/compositor-win32-x64-msvc": {
-      "version": "4.0.499",
-      "resolved": "https://registry.npmjs.org/@remotion/compositor-win32-x64-msvc/-/compositor-win32-x64-msvc-4.0.499.tgz",
-      "integrity": "sha512-sOYpHz3LmW7u0JR3qg3FA2fTP07pEzY6lhKutwTUDAoQ7MJaHdRYBU7DGf/dpBbaGugQ36hi9GKh0jJLbt1aWw==",
+      "version": "4.0.505",
+      "resolved": "https://registry.npmjs.org/@remotion/compositor-win32-x64-msvc/-/compositor-win32-x64-msvc-4.0.505.tgz",
+      "integrity": "sha512-9NSzLa9aMnAN/M3P0EUT1mnhC1EtVR2UUACwOf8eehZgFnxc0nCdhwx4TMS9UubpY7vH81bTl7xq60/BPvBDBQ==",
       "cpu": [
         "x64"
       ],
@@ -1685,32 +1678,26 @@
         "win32"
       ]
     },
-    "node_modules/@remotion/drag-and-drop": {
-      "version": "4.0.499",
-      "resolved": "https://registry.npmjs.org/@remotion/drag-and-drop/-/drag-and-drop-4.0.499.tgz",
-      "integrity": "sha512-0BBcRlRvkfbTo/ZhLLCOlaXvtFGO4Am6M8YGemEjh/HS7wkIkftpWlLDEEJwNeAlWEa11/EYpgWxFGF3huYOBQ==",
-      "license": "Remotion License"
-    },
     "node_modules/@remotion/licensing": {
-      "version": "4.0.499",
-      "resolved": "https://registry.npmjs.org/@remotion/licensing/-/licensing-4.0.499.tgz",
-      "integrity": "sha512-dKjaYAJsxCUXDvAjJW8bHIUe+dYAXEcq2M0RVrqdS1CEUZPUQXhzIbYILX+slcVb5c8/DD5t+edm7d2VSY81Tg==",
+      "version": "4.0.505",
+      "resolved": "https://registry.npmjs.org/@remotion/licensing/-/licensing-4.0.505.tgz",
+      "integrity": "sha512-kHP8puHqEqaiHk+qQDaM7xEPrd/bYbPO/ao9ToePudHiOkueRzCOd24u9ujoMkVJy1FHxFMB/VaYZztwhXFYUw==",
       "license": "MIT"
     },
     "node_modules/@remotion/media-parser": {
-      "version": "4.0.499",
-      "resolved": "https://registry.npmjs.org/@remotion/media-parser/-/media-parser-4.0.499.tgz",
-      "integrity": "sha512-3RX9OFko0gW1ixi87eoYx2FLOndVb4eo/KONIiq0yKwho1IMYAq8r8tIkqmSksVG0RlWqW4FwXa9kp9lhiqfDA==",
+      "version": "4.0.505",
+      "resolved": "https://registry.npmjs.org/@remotion/media-parser/-/media-parser-4.0.505.tgz",
+      "integrity": "sha512-m95m0lc7UODwri8zdDFJcrKZM6CYSvT2fDD1rs0GrvvEf5HK+Puk1X1JZe0jnJATwtnMAguMP+HniS7KRbVTdA==",
       "license": "Remotion License https://remotion.dev/license"
     },
     "node_modules/@remotion/media-utils": {
-      "version": "4.0.499",
-      "resolved": "https://registry.npmjs.org/@remotion/media-utils/-/media-utils-4.0.499.tgz",
-      "integrity": "sha512-XqCX58ZwI80YM9CqzasKYeCVGRaINMhRvaCQ4H953PD+pRkTxk3bFcx97x4oj0Y0KjGDWnBvzsa5Tt0Jx7JUBA==",
+      "version": "4.0.505",
+      "resolved": "https://registry.npmjs.org/@remotion/media-utils/-/media-utils-4.0.505.tgz",
+      "integrity": "sha512-Y5EGhjh7uw3ERR6IUdmEPVyXy5gKDXYNIDM5B1R6WDxeAmybKOGE2aaYB01JrXZbVF+BDizaEZphkiegDlnSHw==",
       "license": "MIT",
       "dependencies": {
         "mediabunny": "1.50.8",
-        "remotion": "4.0.499"
+        "remotion": "4.0.505"
       },
       "peerDependencies": {
         "react": ">=16.8.0",
@@ -1718,12 +1705,12 @@
       }
     },
     "node_modules/@remotion/player": {
-      "version": "4.0.499",
-      "resolved": "https://registry.npmjs.org/@remotion/player/-/player-4.0.499.tgz",
-      "integrity": "sha512-3qEjNUj0KamSgWLXDhXnHdVMIx0EBsdr7XM5+QGldj1EiZH54vXVKJsWJj6SYfPbaskfEWI0wjKGGh0ml3vJrw==",
+      "version": "4.0.505",
+      "resolved": "https://registry.npmjs.org/@remotion/player/-/player-4.0.505.tgz",
+      "integrity": "sha512-xBoYlUsoJLna/h7YcHZcdfjDYQKyRkvf2O5tyk1/q79x8oDF4PSIbLMXHHdwXpb3pWPmOMic0EtYPfugvxdxfQ==",
       "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
-        "remotion": "4.0.499"
+        "remotion": "4.0.505"
       },
       "peerDependencies": {
         "react": ">=16.8.0",
@@ -1731,26 +1718,26 @@
       }
     },
     "node_modules/@remotion/renderer": {
-      "version": "4.0.499",
-      "resolved": "https://registry.npmjs.org/@remotion/renderer/-/renderer-4.0.499.tgz",
-      "integrity": "sha512-KqzYTBIYVWuqKd5tfYaBq9CWKRYZJq6/PL5++/20dQaTSHQQEMTpyyGrOs0RsyCiy8Ofr8eYB765mIeIxulS4Q==",
+      "version": "4.0.505",
+      "resolved": "https://registry.npmjs.org/@remotion/renderer/-/renderer-4.0.505.tgz",
+      "integrity": "sha512-TKhw0v7qeCJenSWBaLS65Irocw+aCDFIs6zp+2ocA6zHk/nAJkdIuhPQU6mWWPs/YGp6U1sPGe1+T3nSeYcEOg==",
       "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
-        "@remotion/licensing": "4.0.499",
-        "@remotion/streaming": "4.0.499",
+        "@remotion/licensing": "4.0.505",
+        "@remotion/streaming": "4.0.505",
         "execa": "5.1.1",
-        "remotion": "4.0.499",
-        "source-map": "0.8.0-beta.0",
+        "remotion": "4.0.505",
+        "source-map": "0.8.0",
         "ws": "8.21.0"
       },
       "optionalDependencies": {
-        "@remotion/compositor-darwin-arm64": "4.0.499",
-        "@remotion/compositor-darwin-x64": "4.0.499",
-        "@remotion/compositor-linux-arm64-gnu": "4.0.499",
-        "@remotion/compositor-linux-arm64-musl": "4.0.499",
-        "@remotion/compositor-linux-x64-gnu": "4.0.499",
-        "@remotion/compositor-linux-x64-musl": "4.0.499",
-        "@remotion/compositor-win32-x64-msvc": "4.0.499"
+        "@remotion/compositor-darwin-arm64": "4.0.505",
+        "@remotion/compositor-darwin-x64": "4.0.505",
+        "@remotion/compositor-linux-arm64-gnu": "4.0.505",
+        "@remotion/compositor-linux-arm64-musl": "4.0.505",
+        "@remotion/compositor-linux-x64-gnu": "4.0.505",
+        "@remotion/compositor-linux-x64-musl": "4.0.505",
+        "@remotion/compositor-win32-x64-msvc": "4.0.505"
       },
       "peerDependencies": {
         "react": ">=16.8.0",
@@ -1758,31 +1745,31 @@
       }
     },
     "node_modules/@remotion/streaming": {
-      "version": "4.0.499",
-      "resolved": "https://registry.npmjs.org/@remotion/streaming/-/streaming-4.0.499.tgz",
-      "integrity": "sha512-PYIZc7KNJyG+qvKYzftrPbfVJw5B31F+6Uage0Qf54c+cpa69Us/kFK8quNbd/zZcwxvGvCR+fCkn41TJ53FfQ==",
+      "version": "4.0.505",
+      "resolved": "https://registry.npmjs.org/@remotion/streaming/-/streaming-4.0.505.tgz",
+      "integrity": "sha512-b3tTq2Dzqe5FlWEW8z69PGqIEgf6atG/374TOReOFEW9c4KQYaYO7Gl+iHMP/ZdE80DiiTaVqneRLpdELX4dMA==",
       "license": "MIT"
     },
     "node_modules/@remotion/studio": {
-      "version": "4.0.499",
-      "resolved": "https://registry.npmjs.org/@remotion/studio/-/studio-4.0.499.tgz",
-      "integrity": "sha512-oW5hvpwZmstFY9zQZuqAjoAUfujoZna2T9Eq636RwhzDqTaCa3zvV8ojrPfAgFOl8XEFwHLK+UPxAijzOXVYMg==",
+      "version": "4.0.505",
+      "resolved": "https://registry.npmjs.org/@remotion/studio/-/studio-4.0.505.tgz",
+      "integrity": "sha512-kMjhB79v5fWYI+3rUtQTzrRn2Lw3a1kK/qMbYYYvNSfbWpAof7AuPCVj1YA93xt8Q0Nna3ISOw7wx2SXdTDzkQ==",
       "license": "MIT",
       "dependencies": {
         "@jridgewell/trace-mapping": "0.3.31",
-        "@remotion/canvas-capture": "4.0.499",
-        "@remotion/drag-and-drop": "4.0.499",
-        "@remotion/media-utils": "4.0.499",
-        "@remotion/player": "4.0.499",
-        "@remotion/renderer": "4.0.499",
-        "@remotion/studio-shared": "4.0.499",
-        "@remotion/timeline-utils": "4.0.499",
-        "@remotion/web-renderer": "4.0.499",
-        "@remotion/zod-types": "4.0.499",
+        "@remotion/captions": "4.0.505",
+        "@remotion/media-utils": "4.0.505",
+        "@remotion/player": "4.0.505",
+        "@remotion/renderer": "4.0.505",
+        "@remotion/studio-protocol": "4.0.505",
+        "@remotion/studio-shared": "4.0.505",
+        "@remotion/timeline-utils": "4.0.505",
+        "@remotion/web-renderer": "4.0.505",
+        "@remotion/zod-types": "4.0.505",
         "mediabunny": "1.50.8",
         "memfs": "3.4.3",
         "open": "8.4.2",
-        "remotion": "4.0.499",
+        "remotion": "4.0.505",
         "semver": "7.5.3",
         "zod": "4.4.3"
       },
@@ -1791,18 +1778,39 @@
         "react-dom": ">=16.8.0"
       }
     },
-    "node_modules/@remotion/studio-server": {
-      "version": "4.0.499",
-      "resolved": "https://registry.npmjs.org/@remotion/studio-server/-/studio-server-4.0.499.tgz",
-      "integrity": "sha512-80VI/QY5ysarjbK6gPn6xysIEhha2r1WIbK2mN4TzVSmQXVTB14YPw1noHwCGuNWETj+V8L34AHpAtZp2yxl9Q==",
+    "node_modules/@remotion/studio-codemods": {
+      "version": "4.0.505",
+      "resolved": "https://registry.npmjs.org/@remotion/studio-codemods/-/studio-codemods-4.0.505.tgz",
+      "integrity": "sha512-TYQ2daceyTMEkd4o0PQ/br0okvNaZBVPwz2zZ6xHic0XCY3YVgtAfs5D4sbBW73A+KtJjk7SxfVtPaTxslhcTA==",
       "license": "MIT",
       "dependencies": {
         "@babel/parser": "7.24.1",
         "@babel/types": "7.24.0",
-        "@remotion/bundler": "4.0.499",
-        "@remotion/drag-and-drop": "4.0.499",
-        "@remotion/renderer": "4.0.499",
-        "@remotion/studio-shared": "4.0.499",
+        "@remotion/studio-shared": "4.0.505",
+        "ast-types": "0.16.1",
+        "recast": "0.23.11",
+        "remotion": "4.0.505"
+      }
+    },
+    "node_modules/@remotion/studio-protocol": {
+      "version": "4.0.505",
+      "resolved": "https://registry.npmjs.org/@remotion/studio-protocol/-/studio-protocol-4.0.505.tgz",
+      "integrity": "sha512-1/6/uX14N8uwgywSYQT9Z3RuTyGTL3n9VsBKmAm3tkoX5jXgCnVHrTgmW7XqW1YyMtTBsFres1I6+6rxWC2xsg==",
+      "license": "Remotion License"
+    },
+    "node_modules/@remotion/studio-server": {
+      "version": "4.0.505",
+      "resolved": "https://registry.npmjs.org/@remotion/studio-server/-/studio-server-4.0.505.tgz",
+      "integrity": "sha512-tLIFWWQFwc05UmdEB1HlqTkaObkHvDhTdD11MZdZZLuCwBR7uXlFxahaslmpTBYzDKT0osct5gluRlywbWht3Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "7.24.1",
+        "@babel/types": "7.24.0",
+        "@remotion/bundler": "4.0.505",
+        "@remotion/renderer": "4.0.505",
+        "@remotion/studio-codemods": "4.0.505",
+        "@remotion/studio-protocol": "4.0.505",
+        "@remotion/studio-shared": "4.0.505",
         "@svgr/core": "8.1.0",
         "@svgr/plugin-jsx": "8.1.0",
         "kiwi-schema": "0.5.0",
@@ -1810,41 +1818,42 @@
         "open": "8.4.2",
         "prettier": "3.8.1",
         "recast": "0.23.11",
-        "remotion": "4.0.499",
-        "semver": "7.5.3"
+        "remotion": "4.0.505",
+        "semver": "7.5.3",
+        "zod": "4.4.3"
       }
     },
     "node_modules/@remotion/studio-shared": {
-      "version": "4.0.499",
-      "resolved": "https://registry.npmjs.org/@remotion/studio-shared/-/studio-shared-4.0.499.tgz",
-      "integrity": "sha512-wGMhqAk8t4UtFneYY8mkUQEWFM95ACQ0Tf87Oh1rPV3RVSN49irQLcBK1eQ8kDM9I9G3oFGQdMYS/6BA8dHnWw==",
+      "version": "4.0.505",
+      "resolved": "https://registry.npmjs.org/@remotion/studio-shared/-/studio-shared-4.0.505.tgz",
+      "integrity": "sha512-0Q8p76ZqTo9q990lGpvBNMeH2a45aqmFBBt8ld2e+KGlSYQPXWAcXaLO73UAycpLr6vge9FRXXYJgmPAynmMyw==",
       "license": "MIT",
       "dependencies": {
-        "@remotion/drag-and-drop": "4.0.499",
-        "remotion": "4.0.499"
+        "@remotion/studio-protocol": "4.0.505",
+        "remotion": "4.0.505"
       }
     },
     "node_modules/@remotion/timeline-utils": {
-      "version": "4.0.499",
-      "resolved": "https://registry.npmjs.org/@remotion/timeline-utils/-/timeline-utils-4.0.499.tgz",
-      "integrity": "sha512-1ml1W9ia/Aaqauqjj7XRMbY3IMIybzZKZJ7C5tm+Dm8lq2QmCH5QQHi84ToLLVOF8T6m/n+wIZXyhUsNQLh94g==",
+      "version": "4.0.505",
+      "resolved": "https://registry.npmjs.org/@remotion/timeline-utils/-/timeline-utils-4.0.505.tgz",
+      "integrity": "sha512-BO81ejrabU5tNmQxd0+hPSZP6JumxVZ8cqGy/iR/AQ9lqfMUtWdrJg9IsOUCT0sEkQyiKwVzeDVji88xBMngOQ==",
       "license": "MIT",
       "dependencies": {
         "mediabunny": "1.50.8"
       }
     },
     "node_modules/@remotion/web-renderer": {
-      "version": "4.0.499",
-      "resolved": "https://registry.npmjs.org/@remotion/web-renderer/-/web-renderer-4.0.499.tgz",
-      "integrity": "sha512-wjxJ1wLrzLxO0nTu/1IdRVd3J1kipzatkfkaXwre8gdEwVTg10XD33niufGuD35ykCH4LGOCmkMlhRcXopJ1lA==",
+      "version": "4.0.505",
+      "resolved": "https://registry.npmjs.org/@remotion/web-renderer/-/web-renderer-4.0.505.tgz",
+      "integrity": "sha512-f2i985v434oi1oxoudDiSj0KFdqiY+8GbhQMHhqI5ag2zsWzBouE2X0WiSnrDd2rLuIlQqE8dIo19Txd24lv1g==",
       "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
         "@mediabunny/aac-encoder": "1.50.8",
         "@mediabunny/flac-encoder": "1.50.8",
         "@mediabunny/mp3-encoder": "1.50.8",
-        "@remotion/licensing": "4.0.499",
+        "@remotion/licensing": "4.0.505",
         "mediabunny": "1.50.8",
-        "remotion": "4.0.499"
+        "remotion": "4.0.505"
       },
       "peerDependencies": {
         "react": ">=18.0.0",
@@ -1852,12 +1861,12 @@
       }
     },
     "node_modules/@remotion/zod-types": {
-      "version": "4.0.499",
-      "resolved": "https://registry.npmjs.org/@remotion/zod-types/-/zod-types-4.0.499.tgz",
-      "integrity": "sha512-UyKMhwnS9T6NgHUznscZ4+pPkvjEIqfd6gEVqW6JkM3C7OcZfOBRcF7FWZZq96eyTIxJHLxCUDdlAZr8JcRlTA==",
+      "version": "4.0.505",
+      "resolved": "https://registry.npmjs.org/@remotion/zod-types/-/zod-types-4.0.505.tgz",
+      "integrity": "sha512-QvsbVae3fQb7ZoYfaAS81huYX/19/4hDIIwzYGlIDCz+SI5UukFd4GNvqcrFu+Uo5kFP+8S98XGlp7KBL+FpHw==",
       "license": "MIT",
       "dependencies": {
-        "remotion": "4.0.499"
+        "remotion": "4.0.505"
       }
     },
     "node_modules/@rspack/binding": {
@@ -2326,18 +2335,18 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "26.1.1",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-26.1.1.tgz",
-      "integrity": "sha512-nxAkRSVkN1Y0JC1W8ky/fTfkGsMmcrRsbx+3XoZE+rMOX71kLYTV7fLXpqud1GpbpP5TuffXFqfX7fH2GgZREw==",
+      "version": "26.1.2",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-26.1.2.tgz",
+      "integrity": "sha512-Vu4a5UFA9rIIFJ7rB/Vaafh9lrCQszopTCx6KjFboXTGQbPNasehVR5TEiithSDGyd1DEiUByggTZsg8jukeIg==",
       "license": "MIT",
       "dependencies": {
         "undici-types": "~8.3.0"
       }
     },
     "node_modules/@types/react": {
-      "version": "19.2.17",
-      "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.17.tgz",
-      "integrity": "sha512-MXfmqaVPEVgkBT/aY0aGCkRWWtByiYQXo3xdQ8r5RzuFrPiRn8Gar2tQdXSUQ2GKV3bkXckek89V8wQBY2Q/Aw==",
+      "version": "19.2.18",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.18.tgz",
+      "integrity": "sha512-AnzbBERsrLKtk2XSfTbYRLjQPdy116Sty4q+T+Bp3IC4l6jNBvreVPAHmpq9qhXQM7CXZPjLVmGMw9sy+hxQ3w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2345,9 +2354,9 @@
       }
     },
     "node_modules/@types/react-dom": {
-      "version": "19.2.3",
-      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-19.2.3.tgz",
-      "integrity": "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==",
+      "version": "19.2.4",
+      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-19.2.4.tgz",
+      "integrity": "sha512-Bsc+QHgp+P/F02XDzNCY9jnZNCUuLki36KT7VKrTXXLdHf+vHMNZnW1rVu5DNW/rCK+fya3DATySbLM4yhtKUw==",
       "dev": true,
       "license": "MIT",
       "peerDependencies": {
@@ -2513,9 +2522,9 @@
       "license": "Apache-2.0"
     },
     "node_modules/acorn": {
-      "version": "8.17.0",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.17.0.tgz",
-      "integrity": "sha512-xRQbDb9BnwDafYNn6Vwl839DYVjqXYb1XVGtWAZ1kcDc6iwAL4hg3B1dZlRiuENFeO2H53gFG3in621AdERVAg==",
+      "version": "8.18.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.18.0.tgz",
+      "integrity": "sha512-lGq+9yr1/GuAWaVYIHRjvvySG5/4VfKIvC8EWxStPdcDh/Ka7FG3twP6v4d5BkravUilhIAsG4Qj83t02LWUPQ==",
       "license": "MIT",
       "bin": {
         "acorn": "bin/acorn"
@@ -2600,9 +2609,9 @@
       }
     },
     "node_modules/baseline-browser-mapping": {
-      "version": "2.11.4",
-      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.11.4.tgz",
-      "integrity": "sha512-s4+sLr9mZ/CyqeRritFeYV/Zx73OAtmaHn6kkBS1XRoJn1hrg3xIDUcpicAEX68tkcIN0iBCgti31C8zxtkhsQ==",
+      "version": "2.11.12",
+      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.11.12.tgz",
+      "integrity": "sha512-r7WnVImvVCeFpf2DOXfy41aPWzeNg3H/A2X4dKmy1QL0MSyyk/e7z8ihJ3N6Nn2PsdhkVlqnEfnUE4a05P2aTA==",
       "license": "Apache-2.0",
       "bin": {
         "baseline-browser-mapping": "dist/cli.cjs"
@@ -2877,15 +2886,15 @@
       }
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.5.396",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.396.tgz",
-      "integrity": "sha512-yHiw2Y3C3H9U6TMbOfoWK/BPreiOPXRfTWPBwQBoZG6/8TB6eOPnsy5oaRYuatR7Fw2SJ4kKforgufeo7fq0EQ==",
+      "version": "1.5.400",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.400.tgz",
+      "integrity": "sha512-96EWDNjM59SYflgeV5Ylsf4EMiq1a25YjCnJH7cxn/AF2H3pILRweaUnoLax0yKHWdpOzY6JKEu45e8irqZIHA==",
       "license": "ISC"
     },
     "node_modules/enhanced-resolve": {
-      "version": "5.24.3",
-      "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.24.3.tgz",
-      "integrity": "sha512-PwKooW9JUzh5chmYfHM3IQl5OkK2u2Nm011MgeZrss3JmFraUx/fqrf78kk8GUMYoibx/14MdwTl/1WKkG7TpQ==",
+      "version": "5.24.5",
+      "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.24.5.tgz",
+      "integrity": "sha512-L1l8TNvomm6UVW5B253AGxQagSQr+vGwhMlrrfRS2qmhx46AMpMVJKQYLvWYbysTMY8VoicOvzHzoHMbyzB+4A==",
       "license": "MIT",
       "dependencies": {
         "graceful-fs": "^4.2.4",
@@ -3264,9 +3273,9 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
-      "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.1.tgz",
+      "integrity": "sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==",
       "funding": [
         {
           "type": "github",
@@ -3357,12 +3366,6 @@
         "type": "opencollective",
         "url": "https://opencollective.com/webpack"
       }
-    },
-    "node_modules/lodash.sortby": {
-      "version": "4.7.0",
-      "resolved": "https://registry.npmjs.org/lodash.sortby/-/lodash.sortby-4.7.0.tgz",
-      "integrity": "sha512-HDWXG8isMntAyRF5vZ7xKuEvOhT4AhlRt/3czTSjvGUxjYCBVRQY48ViDHyfYz9VIoBkW4TMGQNapx+l3RUwdA==",
-      "license": "MIT"
     },
     "node_modules/lower-case": {
       "version": "2.0.2",
@@ -3461,9 +3464,9 @@
       "license": "MIT"
     },
     "node_modules/nanoid": {
-      "version": "3.3.16",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
-      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
+      "version": "3.3.17",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.17.tgz",
+      "integrity": "sha512-xQLf0A3HOMlgHq0n247/LRuAOYmB7dXJ/DvAxGvsSBij45XtBSmQycu+F8ODbHwns/XyFZagyL1+J0Offw1E0g==",
       "funding": [
         {
           "type": "github",
@@ -3495,9 +3498,9 @@
       }
     },
     "node_modules/node-releases": {
-      "version": "2.0.51",
-      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.51.tgz",
-      "integrity": "sha512-wRNIrw4DmVLKQlbgOMdkMx27Wrpzes2hh5Jtbi2bjPd+4wJstWIqP5A+lscnqbm0xxmT5Bpg8Lec5ItEBwx6BQ==",
+      "version": "2.0.52",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.52.tgz",
+      "integrity": "sha512-MRlTqhAfoMx/4mhEbPo3Hi02g9LJZaJkka69V6h67Cb1gjrAG0jsTE4CZX1eptNx+VCAwJmfpnDIF4P0Nh1A7A==",
       "license": "MIT",
       "engines": {
         "node": ">=18"
@@ -3602,9 +3605,9 @@
       "license": "ISC"
     },
     "node_modules/postcss": {
-      "version": "8.5.23",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.23.tgz",
-      "integrity": "sha512-g50586zr4bZmwFiTlflMu8E0bDTb5I5gertgwAKmsdUlTQIhZtunzUlD1WSzwcVWPoAVpsrA6vlfCD7oXvRwgg==",
+      "version": "8.5.25",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.25.tgz",
+      "integrity": "sha512-DTPx3RWSSnWyzLxQnlH0rJP+EW5ekl16ZU4/psbIhA0e53kJfdgaN5vKM+xP7yJtXVu+nfdVFmlgFDEKAe4Pyw==",
       "funding": [
         {
           "type": "opencollective",
@@ -3735,34 +3738,25 @@
         "node": ">= 6"
       }
     },
-    "node_modules/punycode": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
-      "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=6"
-      }
-    },
     "node_modules/react": {
-      "version": "19.2.7",
-      "resolved": "https://registry.npmjs.org/react/-/react-19.2.7.tgz",
-      "integrity": "sha512-HNe9WslTbXmFK8o8cmwgAeJFSBvt1bPdHCVKtaaV+WlAN36mpT4hcRpwbf3fY56ar2oIXzsBpOAiIRHAdY0OlQ==",
+      "version": "19.2.8",
+      "resolved": "https://registry.npmjs.org/react/-/react-19.2.8.tgz",
+      "integrity": "sha512-PWaYA1L/q9u2u7xYQi+Y3L3Yfnie7XyLeaJICV1MGD6LprsBxcAqGjYyr0eY3p+QdsA+x/Irkt4Qif8D63+Sbw==",
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
       }
     },
     "node_modules/react-dom": {
-      "version": "19.2.7",
-      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.7.tgz",
-      "integrity": "sha512-t0BRVXvbiE/o20Hfw669rLbMCDWtYZLvmJigy2f0MxsXF+71pxhR3xOkspmsO8h3ZlNzyibAmtCa3l4lYKk6gQ==",
+      "version": "19.2.8",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.8.tgz",
+      "integrity": "sha512-rVprimfGBG3DR+Tq0IQG2DT5PxKth1WIGDmj5yPmlzr4YBe7uyE+Du4oVqTDXZSHGGGXRtTJEGSSePyQCMBglQ==",
       "license": "MIT",
       "dependencies": {
         "scheduler": "^0.27.0"
       },
       "peerDependencies": {
-        "react": "^19.2.7"
+        "react": "^19.2.8"
       }
     },
     "node_modules/react-refresh": {
@@ -3800,9 +3794,9 @@
       }
     },
     "node_modules/remotion": {
-      "version": "4.0.499",
-      "resolved": "https://registry.npmjs.org/remotion/-/remotion-4.0.499.tgz",
-      "integrity": "sha512-QX5B1XDFBQpr8mYUBqhgCrH0cQJmqfI7zA46k9CsZhri/H9quXObYQBgeNDcxUhoulVvOOjVQqp5d0RAwB94HA==",
+      "version": "4.0.505",
+      "resolved": "https://registry.npmjs.org/remotion/-/remotion-4.0.505.tgz",
+      "integrity": "sha512-Lhi03pimw+Tcer2C0iioJD3c5Iy5hmRJRHtR9XvObhKl0Z4Lpi/EDeTFq1tvU9VVeezU75tVlHYeq+S3TDIiPw==",
       "license": "SEE LICENSE IN LICENSE.md",
       "peerDependencies": {
         "react": ">=16.8.0",
@@ -3992,16 +3986,12 @@
       }
     },
     "node_modules/source-map": {
-      "version": "0.8.0-beta.0",
-      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.8.0-beta.0.tgz",
-      "integrity": "sha512-2ymg6oRBpebeZi9UUNsgQ89bhx01TcTkmNTGnNO88imTmbSgy4nfujrgVEFKWpMTEGA11EDkTt7mqObTPdigIA==",
-      "deprecated": "The work that was done in this beta branch won't be included in future versions",
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.8.0.tgz",
+      "integrity": "sha512-d8EqvL+k/SOXCreS/SUzg2ciyHqBBLcN/yuRjFsbvVhHTE2pgei7oAhmPM7kWFbkX6OSMQfUq4KbkF3au9lhYQ==",
       "license": "BSD-3-Clause",
-      "dependencies": {
-        "whatwg-url": "^7.0.0"
-      },
       "engines": {
-        "node": ">= 8"
+        "node": ">= 12"
       }
     },
     "node_modules/source-map-js": {
@@ -4098,9 +4088,9 @@
       }
     },
     "node_modules/terser": {
-      "version": "5.49.0",
-      "resolved": "https://registry.npmjs.org/terser/-/terser-5.49.0.tgz",
-      "integrity": "sha512-SNiDnXyHSrxVcIOtVbULzcTmniUiwcV7Nwdyj1twVubeTmbjoa8p69KKDpfkdoOavuM4/GRm1+ykI8qqnavHoA==",
+      "version": "5.49.1",
+      "resolved": "https://registry.npmjs.org/terser/-/terser-5.49.1.tgz",
+      "integrity": "sha512-7A2xlQ5EnGT8KPA92dUh6RbRYTVw8hEaEN9L1K68l4UOXFuV511NnAqObGoRqGOQofQcMypisu1s3xawCEHrvA==",
       "license": "BSD-2-Clause",
       "dependencies": {
         "@jridgewell/source-map": "^0.3.3",
@@ -4190,15 +4180,6 @@
         "node": ">=4"
       }
     },
-    "node_modules/tr46": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/tr46/-/tr46-1.0.1.tgz",
-      "integrity": "sha512-dTpowEjclQ7Kgx5SdBkqRzVhERQXov8/l9Ft9dVM9fmg0W0KQSVaXX9T4i6twCPNtYiZM53lpSSUAwJbFPOHxA==",
-      "license": "MIT",
-      "dependencies": {
-        "punycode": "^2.1.0"
-      }
-    },
     "node_modules/tslib": {
       "version": "2.8.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
@@ -4273,12 +4254,6 @@
         "node": ">=10.13.0"
       }
     },
-    "node_modules/webidl-conversions": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-4.0.2.tgz",
-      "integrity": "sha512-YQ+BmxuTgd6UXZW3+ICGfyqRyHXVlD5GtQr5+qjiNW7bF0cqrzX500HVXPBOvgXb5YnzDd+h0zqyv61KUD7+Sg==",
-      "license": "BSD-2-Clause"
-    },
     "node_modules/webpack": {
       "version": "5.105.0",
       "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.105.0.tgz",
@@ -4334,17 +4309,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=10.13.0"
-      }
-    },
-    "node_modules/whatwg-url": {
-      "version": "7.1.0",
-      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-7.1.0.tgz",
-      "integrity": "sha512-WUu7Rg1DroM7oQvGWfOiAK21n74Gg+T4elXEQYkOhtyLeWiJFoOGLXPKI/9gzIie9CtwVLm8wtw6YJdKyxSjeg==",
-      "license": "MIT",
-      "dependencies": {
-        "lodash.sortby": "^4.7.0",
-        "tr46": "^1.0.1",
-        "webidl-conversions": "^4.0.2"
       }
     },
     "node_modules/which": {

--- a/plugins/paper-collage-video/assets/remotion-template/package.json
+++ b/plugins/paper-collage-video/assets/remotion-template/package.json
@@ -1,6 +1,6 @@
 {
   "name": "paper-collage-video-workspace",
-  "version": "0.19.0",
+  "version": "0.19.1-dev.1",
   "description": "Configuration-driven paper-collage video pipeline and Codex plugin built with Remotion.",
   "private": true,
   "type": "module",
@@ -107,14 +107,14 @@
     "fast-uri": "3.1.5"
   },
   "dependencies": {
-    "@remotion/cli": "4.0.499",
-    "react": "19.2.7",
-    "react-dom": "19.2.7",
-    "remotion": "4.0.499"
+    "@remotion/cli": "4.0.505",
+    "react": "19.2.8",
+    "react-dom": "19.2.8",
+    "remotion": "4.0.505"
   },
   "devDependencies": {
-    "@types/react": "19.2.17",
-    "@types/react-dom": "19.2.3",
+    "@types/react": "19.2.18",
+    "@types/react-dom": "19.2.4",
     "sharp": "0.35.3",
     "typescript": "5.9.3"
   }

--- a/plugins/paper-collage-video/assets/remotion-template/projects/starter-demo/quality-report.json
+++ b/plugins/paper-collage-video/assets/remotion-template/projects/starter-demo/quality-report.json
@@ -402,7 +402,7 @@
         "projects/starter-demo/assets/plates/01-bg.png": "8b281acc2007312e394832a74ece76229b8c049d48a46c82f4377409a44a0d57"
       },
       "compositionHash": "9f99e72cb300cc5e8bd58ca115ca06115e677ced2261303824342466747f7c01",
-      "fingerprint": "785bfb0a7944e9f3ad06f360cda8f0e4612bd6099bd06f3d590aa9df68b8092c",
+      "fingerprint": "e11a4aef6c55328e53ca6cffcb33e01622ad9942bbd708f06d577a97a43ec16a",
       "proofTimeIds": [
         "proof-establish"
       ],
@@ -436,8 +436,8 @@
           {
             "id": "proof-current",
             "passed": true,
-            "expected": "785bfb0a7944e9f3ad06f360cda8f0e4612bd6099bd06f3d590aa9df68b8092c",
-            "actual": "785bfb0a7944e9f3ad06f360cda8f0e4612bd6099bd06f3d590aa9df68b8092c"
+            "expected": "e11a4aef6c55328e53ca6cffcb33e01622ad9942bbd708f06d577a97a43ec16a",
+            "actual": "e11a4aef6c55328e53ca6cffcb33e01622ad9942bbd708f06d577a97a43ec16a"
           },
           {
             "id": "proof-artifacts-present",
@@ -485,7 +485,7 @@
         "projects/starter-demo/assets/characters/alpha/01-traveler.png": "5012594d62cc65af7ea21409f9bff9f8b120bfe348c4f2ec0c7f5c0f89b4dd5f"
       },
       "compositionHash": "33ca0da49ad6545fd8c4c140d191c3b619c876ab40e435a6514496d94f6000cb",
-      "fingerprint": "3a0368804159f91798ee0eda4fcd03b2820395db5093dce76549a8d75980319e",
+      "fingerprint": "bccdd4d0417cbab90d867834713e18110f6be786fe3b7486c82ca59763594fa0",
       "proofTimeIds": [
         "proof-action"
       ],
@@ -519,8 +519,8 @@
           {
             "id": "proof-current",
             "passed": true,
-            "expected": "3a0368804159f91798ee0eda4fcd03b2820395db5093dce76549a8d75980319e",
-            "actual": "3a0368804159f91798ee0eda4fcd03b2820395db5093dce76549a8d75980319e"
+            "expected": "bccdd4d0417cbab90d867834713e18110f6be786fe3b7486c82ca59763594fa0",
+            "actual": "bccdd4d0417cbab90d867834713e18110f6be786fe3b7486c82ca59763594fa0"
           },
           {
             "id": "proof-artifacts-present",
@@ -568,7 +568,7 @@
         "projects/starter-demo/assets/characters/alpha/01-traveler.png": "5012594d62cc65af7ea21409f9bff9f8b120bfe348c4f2ec0c7f5c0f89b4dd5f"
       },
       "compositionHash": "e0b2febd866012364c55f448cee0cca01ad63359e1ffe7776b238f7996a82e39",
-      "fingerprint": "43952d84d31ce025b6f07f00ecd0c5182d629a2360b12c96a182cdd0ce768c18",
+      "fingerprint": "01b806cd5efce473cef2827d03ea03cc83ba6d0855f0cd52bd7fe583d8e7c2a5",
       "proofTimeIds": [
         "proof-final"
       ],
@@ -602,8 +602,8 @@
           {
             "id": "proof-current",
             "passed": true,
-            "expected": "43952d84d31ce025b6f07f00ecd0c5182d629a2360b12c96a182cdd0ce768c18",
-            "actual": "43952d84d31ce025b6f07f00ecd0c5182d629a2360b12c96a182cdd0ce768c18"
+            "expected": "01b806cd5efce473cef2827d03ea03cc83ba6d0855f0cd52bd7fe583d8e7c2a5",
+            "actual": "01b806cd5efce473cef2827d03ea03cc83ba6d0855f0cd52bd7fe583d8e7c2a5"
           },
           {
             "id": "proof-artifacts-present",
@@ -653,7 +653,7 @@
         "projects/starter-demo/assets/plates/01-bg.png": "8b281acc2007312e394832a74ece76229b8c049d48a46c82f4377409a44a0d57"
       },
       "compositionHash": "e06069badae5aca97615b854159703f808db6ebab186121be251114657dc1ab0",
-      "fingerprint": "83a36232e4768e96811b449b95b7da710d15d88172efd6b5c8bd2e68e41bd555",
+      "fingerprint": "df6737ab836ff666897f50f01bd6e5438c0ae5a7bc48dad67696c0fb03f699ca",
       "proofTimeIds": [
         "proof-establish",
         "proof-action",
@@ -716,8 +716,8 @@
           {
             "id": "proof-current",
             "passed": true,
-            "expected": "83a36232e4768e96811b449b95b7da710d15d88172efd6b5c8bd2e68e41bd555",
-            "actual": "83a36232e4768e96811b449b95b7da710d15d88172efd6b5c8bd2e68e41bd555"
+            "expected": "df6737ab836ff666897f50f01bd6e5438c0ae5a7bc48dad67696c0fb03f699ca",
+            "actual": "df6737ab836ff666897f50f01bd6e5438c0ae5a7bc48dad67696c0fb03f699ca"
           },
           {
             "id": "proof-artifacts-present",
@@ -759,7 +759,7 @@
         "projects/starter-demo/assets/plates/01-bg.png": "8b281acc2007312e394832a74ece76229b8c049d48a46c82f4377409a44a0d57"
       },
       "compositionHash": "5d49509e53bca73ce5e6e021bfd5f6963e497b332c87aa1351f218df4daaf690",
-      "fingerprint": "feec12f2e7106a93b57784afdca59e35b95882d69c729503207fffdffef69dfb",
+      "fingerprint": "4ee9fd9bfd17afaabd8511067271ef552a22d639abf3248d92aec821dbc928d9",
       "proofTimeIds": [
         "proof-establish",
         "proof-action",
@@ -827,8 +827,8 @@
           {
             "id": "proof-current",
             "passed": true,
-            "expected": "feec12f2e7106a93b57784afdca59e35b95882d69c729503207fffdffef69dfb",
-            "actual": "feec12f2e7106a93b57784afdca59e35b95882d69c729503207fffdffef69dfb"
+            "expected": "4ee9fd9bfd17afaabd8511067271ef552a22d639abf3248d92aec821dbc928d9",
+            "actual": "4ee9fd9bfd17afaabd8511067271ef552a22d639abf3248d92aec821dbc928d9"
           },
           {
             "id": "proof-artifacts-present",
@@ -865,5 +865,5 @@
       "status": "passed"
     }
   ],
-  "reviewSurfaceFingerprint": "2344f04134dd2b8daee1e98f6f2b9a2ee5596c68353c45b6288452079ec2e40f"
+  "reviewSurfaceFingerprint": "6e795429c292e6c458de8334495dc6a9099e1a9f4aa71fd75d3e8b0d3fc3b4f1"
 }

--- a/plugins/paper-collage-video/assets/remotion-template/runtime-build.json
+++ b/plugins/paper-collage-video/assets/remotion-template/runtime-build.json
@@ -1,14 +1,14 @@
 {
   "schemaVersion": 2,
-  "packageVersion": "0.19.0",
-  "fingerprint": "1ab31994036d26e7bc17c1fa0bcffd3a13fa6629f7effdb099d391ceb0c99594",
+  "packageVersion": "0.19.1-dev.1",
+  "fingerprint": "530d4a00d53b9059c6c561206fcb78b48422225913e7d03fed7d73cae1329be0",
   "surfaces": {
-    "final-visual": "9b1335034a7e7aafc0d708df147946c0ee8c0567528f59206608ccbde15af536",
-    "composition-proof": "7b160d55dda64e83b1d321df5940cc0f80793c85d6b6cf02643f7a2b198c6cc8",
-    "audio-delivery": "5673a550c7b9c1b3acff6ee8cdb7592958d1f3a7ae9887886a2ef3734d5a71a4"
+    "final-visual": "cc9e498f89202ddf659938e9bff3cda7d6aa45a4a3bd6c6de705b0f6e52b5d0d",
+    "composition-proof": "04d54b1d927b083ff87c714e7ac150a6bf9cece4ad8ca44a50d613f2dfe6969f",
+    "audio-delivery": "508caaea70a4931c2f3d8a11b3f2e1e1ff0e0fba41987ff6a5d6c9d668e1b3f8"
   },
   "files": {
-    "package.json": "64fc47c8b99b2ad589d3685b58d355d003a90a7013c65c4be86a79a7b36adbd3",
+    "package.json": "17801606d55bf08d3e6e0a57ac7a81275372c8cccc787410d5ba4f073fb59331",
     "requirements.txt": "4d94df48a8bb5659d79504208ee8c26ccfff7e28aa0040dc99c7776b10c735c9",
     "remotion.config.ts": "6b513b6e87a709cd00cd60c87329584379057f6927230af1f96559a3409ed728",
     "schemas/composition.schema.json": "17b55178d9227302962d6b6e8abcd49ec511b2f06bd710e50d712bba568c1e55",

--- a/runtime-build.json
+++ b/runtime-build.json
@@ -1,14 +1,14 @@
 {
   "schemaVersion": 2,
-  "packageVersion": "0.19.0",
-  "fingerprint": "1ab31994036d26e7bc17c1fa0bcffd3a13fa6629f7effdb099d391ceb0c99594",
+  "packageVersion": "0.19.1-dev.1",
+  "fingerprint": "530d4a00d53b9059c6c561206fcb78b48422225913e7d03fed7d73cae1329be0",
   "surfaces": {
-    "final-visual": "9b1335034a7e7aafc0d708df147946c0ee8c0567528f59206608ccbde15af536",
-    "composition-proof": "7b160d55dda64e83b1d321df5940cc0f80793c85d6b6cf02643f7a2b198c6cc8",
-    "audio-delivery": "5673a550c7b9c1b3acff6ee8cdb7592958d1f3a7ae9887886a2ef3734d5a71a4"
+    "final-visual": "cc9e498f89202ddf659938e9bff3cda7d6aa45a4a3bd6c6de705b0f6e52b5d0d",
+    "composition-proof": "04d54b1d927b083ff87c714e7ac150a6bf9cece4ad8ca44a50d613f2dfe6969f",
+    "audio-delivery": "508caaea70a4931c2f3d8a11b3f2e1e1ff0e0fba41987ff6a5d6c9d668e1b3f8"
   },
   "files": {
-    "package.json": "64fc47c8b99b2ad589d3685b58d355d003a90a7013c65c4be86a79a7b36adbd3",
+    "package.json": "17801606d55bf08d3e6e0a57ac7a81275372c8cccc787410d5ba4f073fb59331",
     "requirements.txt": "4d94df48a8bb5659d79504208ee8c26ccfff7e28aa0040dc99c7776b10c735c9",
     "remotion.config.ts": "6b513b6e87a709cd00cd60c87329584379057f6927230af1f96559a3409ed728",
     "schemas/composition.schema.json": "17b55178d9227302962d6b6e8abcd49ec511b2f06bd710e50d712bba568c1e55",


### PR DESCRIPTION
## Summary

Consolidate the five open Dependabot updates into one coherent post-v0.19.0 maintenance change.

- advance the development identity to `0.19.1-dev.1`
- update `remotion` and `@remotion/cli` together from `4.0.499` to `4.0.505`
- update React and React DOM together from `19.2.7` to `19.2.8`
- update `@types/react` to `19.2.18` and `@types/react-dom` to `19.2.4`
- update the transitive `@emnapi/runtime` lock entry to `1.11.3`
- update `actions/setup-python` from v6 to v7 in CI and release workflows
- regenerate the packaged plugin, starter proof artifacts, and runtime fingerprints

This supersedes #22, #23, #25, #26, and #28. Those PRs should be closed only after this consolidated PR passes its required checks.

## Root cause

The failing dependency PRs changed `package.json` or lockfiles without running and committing `npm run plugin:sync`. Because package metadata is part of the executable runtime identity, CI correctly detected drift in the packaged plugin and starter proof fingerprints. Updating Remotion and its CLI separately would also leave their versions inconsistent.

## Validation

- clean root `npm ci`: passed, 0 vulnerabilities
- source tests: 307/307 passed
- source TypeScript check: passed
- source doctor: READY
- source Remotion bundle: passed
- `npm audit --audit-level=moderate`: 0 vulnerabilities
- repeated `npm run plugin:sync`: deterministic and idempotent
- source/package runtime fingerprint match: `530d4a00d53b9059c6c561206fcb78b48422225913e7d03fed7d73cae1329be0`
- fresh packaged workspace `npm ci`: passed, 0 vulnerabilities
- packaged tests: 289/289 passed
- packaged TypeScript check: passed
- packaged doctor: READY
- starter validation: 0 errors / 0 warnings
- starter preview: 36 frames, 7/7 quality checks, production state `complete`

No provider calls, release tags, or stable releases are part of this maintenance PR.
